### PR TITLE
fix: return 401 (not 403) for disallowed Google callback email

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ go.work.sum
 # Editor/IDE
 .idea/
 .vscode/
+.atl/

--- a/internal/infrastructure/port/in/google/routes.go
+++ b/internal/infrastructure/port/in/google/routes.go
@@ -61,7 +61,7 @@ func (h *googleOAuth2HandlerImpl) GoogleCallbackHandler(ctx *gin.Context) {
 	}
 
 	if !userInfo.IsEmailAllowed() {
-		ctx.JSON(http.StatusForbidden, gin.H{
+		ctx.JSON(http.StatusUnauthorized, gin.H{
 			"error": "email is not allowed",
 		})
 		return

--- a/internal/infrastructure/port/in/google/routes_test.go
+++ b/internal/infrastructure/port/in/google/routes_test.go
@@ -216,28 +216,51 @@ func TestGoogleCallbackHandler_ProviderError(t *testing.T) {
 }
 
 func TestGoogleCallbackHandler_EmailNotAllowed(t *testing.T) {
-	setupMockApp("valid-state", []string{"allowed@example.com"}, false, "")
-
-	mockProvider := &mockProviderRepository{
-		userInfo: &model.UserInfo{
-			Email:     "notallowed@example.com",
-			FirstName: "Test",
-			LastName:  "User",
+	testCases := []struct {
+		name            string
+		redirectEnabled bool
+		redirectURL     string
+	}{
+		{
+			name:            "without redirect",
+			redirectEnabled: false,
+			redirectURL:     "",
 		},
-		err: nil,
+		{
+			name:            "with redirect configured",
+			redirectEnabled: true,
+			redirectURL:     "http://localhost:3000/dashboard",
+		},
 	}
-	handler := NewGoogleOAuth2Handler(mockProvider, &mockTokenGenerator{})
 
-	router := gin.New()
-	router.GET("/callback", handler.GoogleCallbackHandler)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			setupMockApp("valid-state", []string{"allowed@example.com"}, tc.redirectEnabled, tc.redirectURL)
 
-	req := httptest.NewRequest(http.MethodGet, "/callback?state=valid-state&code=test-code", nil)
-	w := httptest.NewRecorder()
+			mockProvider := &mockProviderRepository{
+				userInfo: &model.UserInfo{
+					Email:     "notallowed@example.com",
+					FirstName: "Test",
+					LastName:  "User",
+				},
+				err: nil,
+			}
+			handler := NewGoogleOAuth2Handler(mockProvider, &mockTokenGenerator{})
 
-	router.ServeHTTP(w, req)
+			router := gin.New()
+			router.GET("/callback", handler.GoogleCallbackHandler)
 
-	assert.Equal(t, http.StatusForbidden, w.Code)
-	assert.Contains(t, w.Body.String(), "email is not allowed")
+			req := httptest.NewRequest(http.MethodGet, "/callback?state=valid-state&code=test-code", nil)
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusUnauthorized, w.Code)
+			assert.Contains(t, w.Body.String(), "email is not allowed")
+			assert.Empty(t, w.Result().Cookies())
+			assert.Empty(t, w.Header().Get("Location"))
+		})
+	}
 }
 
 func TestGoogleCallbackHandler_TokenGenerationError(t *testing.T) {

--- a/openspec/changes/archive/2026-04-25-fix-google-callback-401/archive-report.md
+++ b/openspec/changes/archive/2026-04-25-fix-google-callback-401/archive-report.md
@@ -1,0 +1,47 @@
+# Archive Report: fix-google-callback-401
+
+## Status
+success
+
+## Executive Summary
+Archived change `fix-google-callback-401` after confirming verification verdict is **PASS WITH WARNINGS** and contains **no CRITICAL issues**. Synced the finalized callback specification into main OpenSpec source-of-truth as a new domain spec and moved the full change folder into dated archive. Persisted traceable archive metadata for both Engram and OpenSpec.
+
+## Artifacts
+- **engram**
+  - `sdd/fix-google-callback-401/explore` (observation #86)
+  - `sdd/fix-google-callback-401/proposal` (observation #88)
+  - `sdd/fix-google-callback-401/spec` (observation #89)
+  - `sdd/fix-google-callback-401/design` (observation #90)
+  - `sdd/fix-google-callback-401/tasks` (observation #91)
+  - `sdd/fix-google-callback-401/apply-progress` (observation #94)
+  - `sdd/fix-google-callback-401/verify-report` (observation #96)
+  - `sdd/fix-google-callback-401/archive-report` (to be persisted by this phase)
+- **openspec**
+  - Source of truth updated: `openspec/specs/google-oauth-callback/spec.md`
+  - Archived change folder: `openspec/changes/archive/2026-04-25-fix-google-callback-401/`
+  - Archive report: `openspec/changes/archive/2026-04-25-fix-google-callback-401/archive-report.md`
+
+## Specs Synced
+| Domain | Action | Details |
+|--------|--------|---------|
+| `google-oauth-callback` | Created | Main spec created from finalized delta spec (requirements define disallowed-email callback as `401`, preserve payload clarity, and keep success-path regression guard coverage). |
+
+## Archive Verification Checklist
+- [x] Main spec updated in source-of-truth (`openspec/specs/google-oauth-callback/spec.md`)
+- [x] Change folder moved to dated archive path
+- [x] Archive contains proposal/spec/design/tasks/verify artifacts
+- [x] Active changes no longer include `fix-google-callback-401`
+- [x] Verify report reviewed: no CRITICAL blockers before archive
+
+## Next Recommended
+none
+
+## Risks
+- Non-blocking process warning remains from verify report: partial TDD safety-net evidence on one callback area.
+- `openspec/config.yaml` is still absent, so future phases cannot enforce OpenSpec-configured archive/verify rules from file.
+
+## Skill Resolution
+injected
+
+## Notes
+- Requested OpenSpec persistence target was `openspec/changes/fix-google-callback-401/archive-report.md`; after archival move, canonical persisted location is `openspec/changes/archive/2026-04-25-fix-google-callback-401/archive-report.md` per OpenSpec archive convention.

--- a/openspec/changes/archive/2026-04-25-fix-google-callback-401/design.md
+++ b/openspec/changes/archive/2026-04-25-fix-google-callback-401/design.md
@@ -1,0 +1,83 @@
+# Design: Align Google Callback Disallowed Email to 401
+
+## Technical Approach
+
+Implement a minimal, handler-local behavior change in `GoogleCallbackHandler`: when `userInfo.IsEmailAllowed()` is false, return `401 Unauthorized` instead of `403 Forbidden`, while preserving the same JSON payload (`{"error":"email is not allowed"}`).
+
+This matches the approved proposal and avoids refactoring route wiring, provider adapters, or domain allowlist logic. The design relies on existing callback flow and updates tests to assert the new status without altering successful authentication behavior.
+
+## Architecture Decisions
+
+| Option | Tradeoff | Decision |
+|---|---|---|
+| Change status code inline in callback handler | Small targeted diff; keeps current error handling style; no shared abstraction | ✅ Chosen |
+| Introduce centralized auth error mapper/middleware | Cleaner long-term semantics, but out of scope and higher blast radius | ❌ Rejected |
+| Change allowlist semantics in domain layer | Could mix authorization semantics with domain logic; unnecessary for this issue | ❌ Rejected |
+
+## Data Flow
+
+No flow shape changes; only one response code changes in an existing branch.
+
+`GET /login/oauth2/code/google`
+
+1. Validate `state` and `code` query params.
+2. Fetch user info via `ProviderRepository.GetUserInfo`.
+3. Check `userInfo.IsEmailAllowed()`.
+4. If false: return `401` + `{"error":"email is not allowed"}`.
+5. If true: generate token, set cookie, then redirect or return `200` token JSON.
+
+```
+Callback Route -> ProviderRepository -> UserInfo
+                                  -> IsEmailAllowed?
+                                        ├─ no  -> 401 JSON error
+                                        └─ yes -> TokenGenerator -> cookie -> redirect|200
+```
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `internal/infrastructure/port/in/google/routes.go` | Modify | Replace `http.StatusForbidden` with `http.StatusUnauthorized` in disallowed-email branch; keep error body unchanged. |
+| `internal/infrastructure/port/in/google/routes_test.go` | Modify | Update disallowed-email assertion to `401`; preserve coverage for success and error branches. |
+
+## Interfaces / Contracts
+
+External HTTP contract update (Google callback disallowed-email case only):
+
+```http
+GET /login/oauth2/code/google?state=...&code=...
+
+Before: 403 {"error":"email is not allowed"}
+After:  401 {"error":"email is not allowed"}
+```
+
+No interface/type changes for:
+- `ports.ProviderRepository`
+- `ports.TokenGenerator`
+- `model.UserInfo.IsEmailAllowed()`
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Unit/Handler | Disallowed email returns `401` and same message | Update `TestGoogleCallbackHandler_EmailNotAllowed` assertion. |
+| Unit/Handler | Success paths remain stable | Keep `TestGoogleCallbackHandler_Success_NoRedirect` and `_WithRedirect` unchanged and passing. |
+| Unit/Handler | Error branches unaffected (`invalid state`, `missing code`, provider/token failures) | Re-run existing tests in `routes_test.go`; maintain explicit branch assertions. |
+
+Note: Existing suite is mostly per-case tests; if touched broadly, prefer table-driven consolidation per project standard, but not required for this narrow status-code change.
+
+## Backward Compatibility
+
+This is a deliberate API behavior change for one failure branch. Clients that currently interpret disallowed-email as `403` must update to handle `401`. Error payload text remains unchanged to reduce migration friction.
+
+## Migration / Rollout
+
+No data migration required. Rollout is immediate with deployment; no feature flag needed given limited scope.
+
+## Rollback
+
+Revert the status constant in `internal/infrastructure/port/in/google/routes.go` from `http.StatusUnauthorized` back to `http.StatusForbidden`, restore corresponding test assertion(s) in `routes_test.go`, and rerun callback handler tests.
+
+## Open Questions
+
+- [ ] Should we document auth status-code semantics (`401` vs `403`) in a shared API contract to avoid divergence across handlers?

--- a/openspec/changes/archive/2026-04-25-fix-google-callback-401/exploration.md
+++ b/openspec/changes/archive/2026-04-25-fix-google-callback-401/exploration.md
@@ -1,0 +1,31 @@
+## Exploration: fix-google-callback-401
+
+### Current State
+The Google OAuth callback handler currently validates `state` and `code`, fetches user info from the provider, validates the user email against configured allowlist, and then issues a token/cookie plus optional redirect. In the disallowed-email branch (`!userInfo.IsEmailAllowed()`), it returns `403 Forbidden` with payload `{ "error": "email is not allowed" }`. Existing unit tests in the Google callback suite assert `403` for that path.
+
+### Affected Areas
+- `internal/infrastructure/port/in/google/routes.go` — contains the callback branch that currently returns `http.StatusForbidden` for disallowed email.
+- `internal/infrastructure/port/in/google/routes_test.go` — `TestGoogleCallbackHandler_EmailNotAllowed` currently expects `http.StatusForbidden`; must assert `http.StatusUnauthorized`.
+- `internal/domain/model/user_info.go` — provides `IsEmailAllowed()` behavior used by callback flow; no behavior change expected, but relevant to branch coverage.
+- `internal/infrastructure/port/in/server/server.go` — route registration for callback endpoint; no code change expected, but confirms impacted endpoint (`/login/oauth2/code/google`).
+
+### Approaches
+1. **Targeted status-code correction** — Change only the disallowed-email HTTP status from 403 to 401 and update related tests.
+   - Pros: Minimal, low-risk, directly satisfies acceptance criteria, preserves existing payload/message and success flow behavior.
+   - Cons: Keeps authorization semantics embedded in handler (not centralized).
+   - Effort: Low.
+
+2. **Centralized auth error mapping** — Introduce shared auth error types/mapping and make callback return mapped status for disallowed identity.
+   - Pros: Better long-term consistency across handlers/middleware.
+   - Cons: Larger scope for a small bugfix, higher regression risk, unnecessary for current issue.
+   - Effort: Medium.
+
+### Recommendation
+Use **Approach 1 (Targeted status-code correction)**. It is the smallest possible change to meet issue #2 and all acceptance criteria: disallowed email returns 401, payload stays actionable, tests align with 401, and successful callback/login flow remains untouched.
+
+### Risks
+- Semantic/API compatibility risk: clients that previously treated this specific branch as 403 may need to handle 401 (expected per issue alignment with Java service).
+- Test coverage risk: if only one test is updated, hidden assumptions in other integration paths could remain unverified; run callback test suite to confirm no success-flow regression.
+
+### Ready for Proposal
+Yes — exploration is sufficient to move to proposal/spec/tasks for a focused bugfix that updates callback unauthorized behavior and corresponding tests.

--- a/openspec/changes/archive/2026-04-25-fix-google-callback-401/implementation-notes.md
+++ b/openspec/changes/archive/2026-04-25-fix-google-callback-401/implementation-notes.md
@@ -1,0 +1,56 @@
+# Implementation Notes: fix-google-callback-401
+
+## Summary
+
+Aligned Google callback disallowed-email handling from `403 Forbidden` to `401 Unauthorized` while preserving the existing payload contract (`{"error":"email is not allowed"}`) and keeping early-return behavior.
+
+## Code Changes
+
+- `internal/infrastructure/port/in/google/routes.go`
+  - Changed disallowed-email branch status code: `http.StatusForbidden` → `http.StatusUnauthorized`.
+- `internal/infrastructure/port/in/google/routes_test.go`
+  - Updated disallowed-email assertions to `401`.
+  - Refactored disallowed-email test into table-driven subtests (`without redirect`, `with redirect configured`).
+  - Added explicit assertions that no cookie is issued and no redirect location is set for disallowed-email responses.
+
+## Verification Executed
+
+- Focused disallowed-email test:
+  - `go test ./internal/infrastructure/port/in/google -run TestGoogleCallbackHandler_EmailNotAllowed`
+- Error-branch regression checks:
+  - `go test ./internal/infrastructure/port/in/google -run "TestGoogleCallbackHandler_(InvalidState|MissingCode|ProviderError|TokenGenerationError)"`
+- Success-flow regression checks:
+  - `go test ./internal/infrastructure/port/in/google -run TestGoogleCallbackHandler_Success_NoRedirect`
+  - `go test ./internal/infrastructure/port/in/google -run TestGoogleCallbackHandler_Success_WithRedirect`
+- Package regression:
+  - `go test ./internal/infrastructure/port/in/google`
+- Full suite:
+  - `go test ./...`
+
+All commands passed after implementation.
+
+## Contract Check
+
+Manual check against:
+- `openspec/changes/fix-google-callback-401/spec.md`
+- `openspec/changes/fix-google-callback-401/design.md`
+
+Result: implementation matches required behavior (`401` + unchanged payload) and preserves successful callback flows.
+
+## Post-Verify Blocker Remediation
+
+Verifier reported a project-level strict gate failure in `go vet ./...`:
+
+- `pkg/application_test.go:105:19: call of assert.NotNil copies lock value`
+
+Minimal, non-behavioral fix applied in tests only:
+
+- `pkg/application_test.go`
+  - Replaced `assert.NotNil(t, app.Server)` with `assert.NotNil(t, app.Server.Handler)` to avoid copying `http.Server` (which embeds noCopy locks).
+  - Kept all original semantic checks (`Addr`, timeouts, header bytes) unchanged.
+
+Validation after fix:
+
+- `go test ./pkg -run "TestApplication_(UseServer|ChainedMethodCalls)"` ✅
+- `go vet ./...` ✅
+- `go test ./...` ✅

--- a/openspec/changes/archive/2026-04-25-fix-google-callback-401/proposal.md
+++ b/openspec/changes/archive/2026-04-25-fix-google-callback-401/proposal.md
@@ -1,0 +1,57 @@
+# Proposal: Align Google Callback Disallowed Email to 401
+
+## Intent
+
+Issue #2 requires parity with upstream auth semantics: when Google OAuth callback receives a disallowed email, return `401 Unauthorized` (not `403`) while keeping the response payload clear and preserving successful login behavior.
+
+## Scope
+
+### In Scope
+- Update Google callback disallowed-email response status from `403` to `401`.
+- Preserve existing error payload/message clarity for this branch.
+- Update callback tests to assert `401` and verify no regression in success path.
+
+### Out of Scope
+- Refactoring callback error handling into shared/global error mappers.
+- Changing allowlist logic, user model behavior, or OAuth route wiring.
+
+## Capabilities
+
+### New Capabilities
+- `google-oauth-callback`: Defines callback response semantics for allowed and disallowed emails, including unauthorized handling.
+
+### Modified Capabilities
+- None.
+
+## Approach
+
+Apply a targeted handler change in the disallowed-email branch (`!userInfo.IsEmailAllowed()`), replacing `http.StatusForbidden` with `http.StatusUnauthorized`. Keep payload unchanged. Update unit tests in the Google callback suite (table-driven where applicable) to cover success and disallowed-email error branches explicitly.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `internal/infrastructure/port/in/google/routes.go` | Modified | Disallowed-email callback status becomes `401`. |
+| `internal/infrastructure/port/in/google/routes_test.go` | Modified | Assertions updated to `401`; success + error branch coverage preserved. |
+| `openspec/changes/fix-google-callback-401/specs/` | New | Delta spec(s) for callback unauthorized behavior. |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Clients expecting `403` may need adaptation | Medium | Communicate API contract update in issue/PR notes. |
+| Hidden assumptions in callback tests | Low | Run callback-focused tests covering success and disallowed-email paths. |
+
+## Rollback Plan
+
+Revert the status constant change in `routes.go` and restore previous test expectations in `routes_test.go`; rerun callback test suite to confirm behavior returns to pre-change baseline.
+
+## Dependencies
+
+- Existing Google OAuth callback handler and test harness in current codebase.
+
+## Success Criteria
+
+- [ ] Disallowed-email callback response returns HTTP `401 Unauthorized`.
+- [ ] Error payload remains explicit and unchanged in meaning.
+- [ ] Callback success path tests still pass with no behavioral regression.

--- a/openspec/changes/archive/2026-04-25-fix-google-callback-401/spec.md
+++ b/openspec/changes/archive/2026-04-25-fix-google-callback-401/spec.md
@@ -1,0 +1,47 @@
+# Google OAuth Callback Specification
+
+## Purpose
+
+Define callback response behavior for allowed and disallowed Google-authenticated emails, aligning disallowed-email handling to `401 Unauthorized` while preserving successful login behavior.
+
+## Requirements
+
+### Requirement: Disallowed Email Callback Returns Unauthorized
+
+The system MUST return HTTP `401 Unauthorized` when the Google OAuth callback resolves a user whose email is not allowed by configured policy.
+
+#### Scenario: Disallowed email in callback
+
+- GIVEN a valid callback request (`state` and `code`) and provider user info with a disallowed email
+- WHEN the callback handler evaluates allowlist policy
+- THEN the response status SHALL be `401`
+- AND the login session/token issuance MUST NOT proceed
+
+### Requirement: Unauthorized Payload Remains Clear and Actionable
+
+The system MUST preserve a clear, actionable response payload for disallowed-email callback responses; the payload semantics SHOULD remain unchanged except for status alignment to `401`.
+
+#### Scenario: Payload clarity for disallowed email
+
+- GIVEN a callback request that reaches the disallowed-email branch
+- WHEN the handler returns unauthorized
+- THEN the response payload MUST include the same explicit disallowed-email meaning used previously
+- AND clients SHALL be able to identify the response as an authorization failure without ambiguity
+
+### Requirement: Callback Test Suite Reflects Unauthorized Contract
+
+The callback test suite MUST assert `401` for disallowed-email outcomes and MUST continue to cover both success and error branches.
+
+#### Scenario: Test expectation updated for disallowed email
+
+- GIVEN callback tests for disallowed-email handling
+- WHEN tests execute against current callback behavior
+- THEN expected status MUST be `401`
+- AND assertions for payload clarity SHALL remain validated
+
+#### Scenario: Success flow regression guard remains intact
+
+- GIVEN callback tests for allowed-email login flow
+- WHEN tests execute after unauthorized-status alignment
+- THEN successful callback/login behavior MUST remain unchanged
+- AND success-path assertions SHALL continue to pass

--- a/openspec/changes/archive/2026-04-25-fix-google-callback-401/tasks.md
+++ b/openspec/changes/archive/2026-04-25-fix-google-callback-401/tasks.md
@@ -1,0 +1,23 @@
+# Tasks: Align Google Callback Disallowed Email to 401
+
+## Phase 1: Foundation
+
+- [x] 1.1 Inspect `internal/infrastructure/port/in/google/routes.go` and confirm the disallowed-email branch currently returns `http.StatusForbidden` with `{"error":"email is not allowed"}`.
+- [x] 1.2 Review `internal/infrastructure/port/in/google/routes_test.go` callback coverage and identify cases to keep explicit for success + error branches (per project testing standard).
+
+## Phase 2: Core Implementation
+
+- [x] 2.1 Update `internal/infrastructure/port/in/google/routes.go` to return `http.StatusUnauthorized` in the `!userInfo.IsEmailAllowed()` branch.
+- [x] 2.2 Preserve existing unauthorized payload semantics in `internal/infrastructure/port/in/google/routes.go` (`{"error":"email is not allowed"}`) and keep early-return behavior so token/cookie issuance does not execute.
+
+## Phase 3: Test Updates
+
+- [x] 3.1 Update disallowed-email callback assertion(s) in `internal/infrastructure/port/in/google/routes_test.go` to expect `401` and unchanged error payload.
+- [x] 3.2 Keep or refactor callback tests in `internal/infrastructure/port/in/google/routes_test.go` into table-driven form if multiple cases are touched, ensuring explicit coverage for allowed/disallowed outcomes.
+- [x] 3.3 Re-assert existing error branches in `internal/infrastructure/port/in/google/routes_test.go` (invalid state, missing code, provider/token failures) remain unchanged.
+
+## Phase 4: Verification
+
+- [x] 4.1 Run focused callback tests for `internal/infrastructure/port/in/google/routes_test.go` and verify disallowed-email case now returns `401`.
+- [x] 4.2 Run package-level regression tests for `internal/infrastructure/port/in/google` to validate success paths (`TestGoogleCallbackHandler_Success_NoRedirect`, `TestGoogleCallbackHandler_Success_WithRedirect`) still pass.
+- [x] 4.3 Perform a manual contract check against `openspec/changes/fix-google-callback-401/spec.md` and `openspec/changes/fix-google-callback-401/design.md` to confirm implementation matches required status and payload semantics.

--- a/openspec/changes/archive/2026-04-25-fix-google-callback-401/verify-report.md
+++ b/openspec/changes/archive/2026-04-25-fix-google-callback-401/verify-report.md
@@ -1,0 +1,147 @@
+# Verification Report
+
+**Change**: fix-google-callback-401  
+**Version**: N/A  
+**Mode**: Strict TDD
+
+---
+
+### Completeness
+| Metric | Value |
+|--------|-------|
+| Tasks total | 10 |
+| Tasks complete | 10 |
+| Tasks incomplete | 0 |
+
+All tasks in `openspec/changes/fix-google-callback-401/tasks.md` are marked complete.
+
+---
+
+### Build & Tests Execution
+
+**Build / Type-check**: ✅ Passed
+```text
+Command: go vet ./...
+Result: passed (no diagnostics)
+```
+
+**Tests (focused callback package)**: ✅ 11 passed / ❌ 0 failed / ⚠️ 0 skipped
+```text
+Command: go test -v ./internal/infrastructure/port/in/google
+PASS
+ok   github.com/matiasmartin-labs/auth-provider-ms/internal/infrastructure/port/in/google	(cached)
+```
+
+**Tests (full suite)**: ✅ Passed
+```text
+Command: go test ./...
+Result: all packages passed (no failing tests)
+```
+
+**Coverage**: 82.4% total / threshold: N/A → ➖ No configured threshold
+```text
+Command: go test -coverprofile=coverage.out ./... && go tool cover -func=coverage.out
+Total: 82.4%
+Changed production file coverage:
+- internal/infrastructure/port/in/google/routes.go: 100.0%
+```
+
+---
+
+### TDD Compliance
+| Check | Result | Details |
+|-------|--------|---------|
+| TDD Evidence reported | ✅ | Found in `sdd/fix-google-callback-401/apply-progress` (`TDD Cycle Evidence` table present) |
+| All tasks have tests | ✅ | 3/3 TDD rows reference existing test files (`routes_test.go`, `application_test.go`) |
+| RED confirmed (tests exist) | ✅ | Referenced test files exist and are exercised |
+| GREEN confirmed (tests pass) | ✅ | Relevant tests now pass in focused and full runs |
+| Triangulation adequate | ✅ | Callback denial path has two subcases; success/error branches are independently asserted |
+| Safety Net for modified files | ⚠️ | One TDD row records `⚠️ Partial` safety-net evidence in apply-progress |
+
+**TDD Compliance**: 5/6 checks passed
+
+---
+
+### Test Layer Distribution
+| Layer | Tests | Files | Tools |
+|-------|-------|-------|-------|
+| Unit | 9 | 1 | `go test` (`pkg/application_test.go`) |
+| Integration | 11 | 1 | `net/http/httptest` + Gin route tests (`routes_test.go`, includes subtests) |
+| E2E | 0 | 0 | not installed |
+| **Total** | **20** | **2** | |
+
+---
+
+### Changed File Coverage
+| File | Line % | Branch % | Uncovered Lines | Rating |
+|------|--------|----------|-----------------|--------|
+| `internal/infrastructure/port/in/google/routes.go` | 100% | N/A (Go cover reports statement/function coverage) | — | ✅ Excellent |
+| `internal/infrastructure/port/in/google/routes_test.go` | N/A (test file) | N/A | N/A | ➖ Informational |
+| `pkg/application_test.go` | N/A (test file) | N/A | N/A | ➖ Informational |
+
+**Average changed production-file coverage**: 100%
+
+---
+
+### Assertion Quality
+**Assertion quality**: ✅ All assertions verify real behavior
+
+---
+
+### Quality Metrics
+**Linter**: ➖ Not available  
+**Type Checker**: ✅ `go vet ./...` passed
+
+---
+
+### Spec Compliance Matrix
+
+| Requirement | Scenario | Test | Result |
+|-------------|----------|------|--------|
+| Disallowed Email Callback Returns Unauthorized | Disallowed email in callback | `internal/infrastructure/port/in/google/routes_test.go > TestGoogleCallbackHandler_EmailNotAllowed/without_redirect` and `/with_redirect_configured` | ✅ COMPLIANT |
+| Unauthorized Payload Remains Clear and Actionable | Payload clarity for disallowed email | `internal/infrastructure/port/in/google/routes_test.go > TestGoogleCallbackHandler_EmailNotAllowed/*` (asserts `"email is not allowed"`) | ✅ COMPLIANT |
+| Callback Test Suite Reflects Unauthorized Contract | Test expectation updated for disallowed email | `internal/infrastructure/port/in/google/routes_test.go > TestGoogleCallbackHandler_EmailNotAllowed/*` (asserts `401`) | ✅ COMPLIANT |
+| Callback Test Suite Reflects Unauthorized Contract | Success flow regression guard remains intact | `internal/infrastructure/port/in/google/routes_test.go > TestGoogleCallbackHandler_Success_NoRedirect` and `..._WithRedirect` | ✅ COMPLIANT |
+
+**Compliance summary**: 4/4 scenarios compliant
+
+---
+
+### Correctness (Static — Structural Evidence)
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| Disallowed Email Callback Returns Unauthorized | ✅ Implemented | `GoogleCallbackHandler` returns `http.StatusUnauthorized` when `!userInfo.IsEmailAllowed()` in `routes.go`. |
+| Unauthorized Payload Remains Clear and Actionable | ✅ Implemented | Error payload remains `{"error":"email is not allowed"}`; tests assert same semantic message. |
+| Callback Test Suite Reflects Unauthorized Contract | ✅ Implemented | Disallowed-email tests assert `401`; success and error branches remain present and passing. |
+
+---
+
+### Coherence (Design)
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| Change status code inline in callback handler | ✅ Yes | Implemented exactly as designed in `routes.go`. |
+| Keep payload unchanged for disallowed email | ✅ Yes | Payload string unchanged and asserted in tests. |
+| Preserve success path behavior | ✅ Yes | Success tests pass with unchanged expectations. |
+| Avoid broader auth/error refactor | ✅ Yes | No runtime refactor introduced. |
+| File Changes table alignment | ⚠️ Deviated | Additional test-only file `pkg/application_test.go` changed for vet remediation; no behavior change to callback flow. |
+
+---
+
+### Issues Found
+
+**CRITICAL** (must fix before archive):
+None.
+
+**WARNING** (should fix):
+1. TDD safety-net evidence remains partial for one modified callback test area (as recorded in apply-progress), reducing strict pre-change regression confidence.
+2. `openspec/config.yaml` is missing, so project-level verify/build/coverage rule checks cannot be validated from OpenSpec config.
+
+**SUGGESTION** (nice to have):
+1. Document shared `401` vs `403` semantics in an API contract to prevent future handler-level divergence.
+
+---
+
+### Verdict
+**PASS WITH WARNINGS**
+
+Behavioral and structural verification passes for this change (4/4 scenarios compliant; `go vet ./...` and `go test ./...` pass), with only non-blocking process/config warnings remaining.

--- a/openspec/specs/google-oauth-callback/spec.md
+++ b/openspec/specs/google-oauth-callback/spec.md
@@ -1,0 +1,47 @@
+# Google OAuth Callback Specification
+
+## Purpose
+
+Define callback response behavior for allowed and disallowed Google-authenticated emails, aligning disallowed-email handling to `401 Unauthorized` while preserving successful login behavior.
+
+## Requirements
+
+### Requirement: Disallowed Email Callback Returns Unauthorized
+
+The system MUST return HTTP `401 Unauthorized` when the Google OAuth callback resolves a user whose email is not allowed by configured policy.
+
+#### Scenario: Disallowed email in callback
+
+- GIVEN a valid callback request (`state` and `code`) and provider user info with a disallowed email
+- WHEN the callback handler evaluates allowlist policy
+- THEN the response status SHALL be `401`
+- AND the login session/token issuance MUST NOT proceed
+
+### Requirement: Unauthorized Payload Remains Clear and Actionable
+
+The system MUST preserve a clear, actionable response payload for disallowed-email callback responses; the payload semantics SHOULD remain unchanged except for status alignment to `401`.
+
+#### Scenario: Payload clarity for disallowed email
+
+- GIVEN a callback request that reaches the disallowed-email branch
+- WHEN the handler returns unauthorized
+- THEN the response payload MUST include the same explicit disallowed-email meaning used previously
+- AND clients SHALL be able to identify the response as an authorization failure without ambiguity
+
+### Requirement: Callback Test Suite Reflects Unauthorized Contract
+
+The callback test suite MUST assert `401` for disallowed-email outcomes and MUST continue to cover both success and error branches.
+
+#### Scenario: Test expectation updated for disallowed email
+
+- GIVEN callback tests for disallowed-email handling
+- WHEN tests execute against current callback behavior
+- THEN expected status MUST be `401`
+- AND assertions for payload clarity SHALL remain validated
+
+#### Scenario: Success flow regression guard remains intact
+
+- GIVEN callback tests for allowed-email login flow
+- WHEN tests execute after unauthorized-status alignment
+- THEN successful callback/login behavior MUST remain unchanged
+- AND success-path assertions SHALL continue to pass

--- a/pkg/application_test.go
+++ b/pkg/application_test.go
@@ -102,7 +102,7 @@ func TestApplication_UseServer(t *testing.T) {
 	result := app.UseServer()
 
 	assert.Same(t, app, result) // Returns same instance for chaining
-	assert.NotNil(t, app.Server)
+	assert.NotNil(t, app.Server.Handler)
 	assert.Equal(t, ":8080", app.Server.Addr)
 	assert.Equal(t, 10*time.Second, app.Server.ReadTimeout)
 	assert.Equal(t, 15*time.Second, app.Server.WriteTimeout)


### PR DESCRIPTION
Closes #2

## Summary
- Align Google OAuth callback unauthorized semantics by returning `401` when the authenticated email is not in the allowlist.
- Preserve the existing error payload (`email is not allowed`) and keep successful callback/login behavior unchanged.
- Include hybrid SDD artifact trail (proposal/spec/design/tasks/verify/archive) and synced callback spec under `openspec/specs/`.

## Changes
| File | Change |
|------|--------|
| `internal/infrastructure/port/in/google/routes.go` | Changed disallowed-email callback response from `403` to `401`. |
| `internal/infrastructure/port/in/google/routes_test.go` | Updated assertions to `401`; added table-driven disallowed-email subcases and no-cookie/no-redirect checks. |
| `pkg/application_test.go` | Fixed `go vet` `copylocks` warning in test assertion (`app.Server.Handler`). |
| `openspec/**` | Added archived hybrid SDD artifacts and synced callback specification. |
| `.gitignore` | Added `.atl/` ignore entry for local SDD registry/bootstrap artifacts. |

## Test Plan
- [x] `go test ./internal/infrastructure/port/in/google`
- [x] `go vet ./...`
- [x] `go test ./...`

## Notes
- Verification result for the scoped change is PASS WITH WARNINGS (no CRITICAL blockers).