### PR TITLE
feat: add POST /api/v1/auth/sign-out endpoint for Java parity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ go.work.sum
 .idea/
 .vscode/
 .atl/
+test-report.json

--- a/internal/infrastructure/port/in/server/server.go
+++ b/internal/infrastructure/port/in/server/server.go
@@ -4,6 +4,7 @@ import (
 	"github.com/matiasmartin-labs/auth-provider-ms/internal/infrastructure/port/in/google"
 	"github.com/matiasmartin-labs/auth-provider-ms/internal/infrastructure/port/in/jwks"
 	"github.com/matiasmartin-labs/auth-provider-ms/internal/infrastructure/port/in/me"
+	"github.com/matiasmartin-labs/auth-provider-ms/internal/infrastructure/port/in/signout"
 	googleClient "github.com/matiasmartin-labs/auth-provider-ms/internal/infrastructure/port/out/google"
 	"github.com/matiasmartin-labs/auth-provider-ms/internal/infrastructure/port/out/token"
 	"github.com/matiasmartin-labs/auth-provider-ms/pkg"
@@ -17,6 +18,7 @@ func Routes(app *pkg.Application) error {
 	app.RegisterGET("/.well-known/jwks.json", jwks.JwksHandler)
 	app.RegisterGET("/login/oauth2/code/google", googleHandler.GoogleCallbackHandler)
 	app.RegisterGET("/oauth2/authorization/google", googleHandler.GoogleLoginHandler)
+	app.RegisterPOST("/api/v1/auth/sign-out", signout.SignOutHandler)
 
 	app.RegisterProtectedGET("/api/v1/auth/me", me.MeHandler)
 

--- a/internal/infrastructure/port/in/server/server_test.go
+++ b/internal/infrastructure/port/in/server/server_test.go
@@ -1,0 +1,90 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/matiasmartin-labs/auth-provider-ms/pkg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createServerTestConfig(t *testing.T) (cleanup func()) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	configContent := `
+server:
+  port: 8080
+  read-timeout: 10s
+  write-timeout: 15s
+  max-header-bytes: 1048576
+security:
+  oauth2:
+    client:
+      google:
+        client-id: test-client-id
+        client-secret: test-secret
+        redirect-uri: http://localhost:8080/callback
+        scopes:
+          - email
+          - profile
+        state: random-state
+        user-info-uri: https://www.googleapis.com/oauth2/v2/userinfo
+  redirect:
+    enabled: false
+    url: ""
+  cookie:
+    secure: false
+    max-age: 1h
+    http-only: true
+    same-site: Lax
+  login:
+    allowed-emails:
+      - test@example.com
+  jwt:
+    issuer: test-issuer
+    audience: test-audience
+    expiration-time: 1h
+  auth:
+    enabled: true
+`
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	err := os.WriteFile(configPath, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	originalDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+
+	return func() {
+		require.NoError(t, os.Chdir(originalDir))
+	}
+}
+
+func TestRoutes_RegistersSignOutEndpoint(t *testing.T) {
+	cleanup := createServerTestConfig(t)
+	defer cleanup()
+
+	gin.SetMode(gin.TestMode)
+
+	app := pkg.NewApplication().
+		UseConfig().
+		UseServer().
+		UseServerSecurity()
+
+	err := Routes(app)
+	require.NoError(t, err)
+
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/auth/sign-out", nil)
+	response := httptest.NewRecorder()
+
+	app.Server.Handler.ServeHTTP(response, request)
+
+	assert.NotEqual(t, http.StatusNotFound, response.Code)
+	assert.Equal(t, http.StatusNoContent, response.Code)
+}

--- a/internal/infrastructure/port/in/signout/routes.go
+++ b/internal/infrastructure/port/in/signout/routes.go
@@ -1,0 +1,31 @@
+package signout
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/matiasmartin-labs/auth-provider-ms/pkg"
+)
+
+func SignOutHandler(ctx *gin.Context) {
+	ctx.SetCookie("token", "", 0, "/", "", resolveCookieSecure(), true)
+	ctx.Status(http.StatusNoContent)
+}
+
+func resolveCookieSecure() bool {
+	if pkg.App == nil || pkg.App.Config == nil {
+		return false
+	}
+
+	securityConfig := pkg.App.Config.GetSecurityConfig()
+	if securityConfig == nil {
+		return false
+	}
+
+	cookieConfig := securityConfig.GetCookieConfig()
+	if cookieConfig == nil {
+		return false
+	}
+
+	return cookieConfig.GetSecure()
+}

--- a/internal/infrastructure/port/in/signout/routes_test.go
+++ b/internal/infrastructure/port/in/signout/routes_test.go
@@ -1,0 +1,140 @@
+package signout
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/matiasmartin-labs/auth-provider-ms/pkg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testCookieConfig struct {
+	secure bool
+}
+
+func (c *testCookieConfig) GetSecure() bool          { return c.secure }
+func (c *testCookieConfig) GetHTTPOnly() bool        { return false }
+func (c *testCookieConfig) GetSameSite() string      { return "" }
+func (c *testCookieConfig) GetMaxAge() time.Duration { return 0 }
+
+type testSecurityConfig struct {
+	cookieConfig pkg.CookieConfig
+}
+
+func (s *testSecurityConfig) GetOAuth2Config() pkg.OAuth2Config     { return nil }
+func (s *testSecurityConfig) GetRedirectConfig() pkg.RedirectConfig { return nil }
+func (s *testSecurityConfig) GetCookieConfig() pkg.CookieConfig     { return s.cookieConfig }
+func (s *testSecurityConfig) GetLoginConfig() pkg.LoginConfig       { return nil }
+func (s *testSecurityConfig) GetJWTConfig() pkg.JWTConfig           { return nil }
+func (s *testSecurityConfig) GetAuthConfig() pkg.AuthConfig         { return nil }
+
+type testConfiguration struct {
+	securityConfig pkg.SecurityConfig
+}
+
+func (c *testConfiguration) GetServerConfig() pkg.ServerConfig     { return nil }
+func (c *testConfiguration) GetSecurityConfig() pkg.SecurityConfig { return c.securityConfig }
+
+func TestSignOutHandler_ClearsTokenCookieAndReturnsNoContent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	testCases := []struct {
+		name           string
+		secureEnabled  bool
+		expectedSecure bool
+	}{
+		{
+			name:           "secure cookie disabled",
+			secureEnabled:  false,
+			expectedSecure: false,
+		},
+		{
+			name:           "secure cookie enabled",
+			secureEnabled:  true,
+			expectedSecure: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pkg.App = &pkg.Application{
+				Config: &testConfiguration{
+					securityConfig: &testSecurityConfig{cookieConfig: &testCookieConfig{secure: tc.secureEnabled}},
+				},
+			}
+
+			router := gin.New()
+			router.POST("/api/v1/auth/sign-out", SignOutHandler)
+
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/sign-out", nil)
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusNoContent, w.Code)
+			assert.Empty(t, w.Body.String())
+
+			tokenCookie := findTokenCookie(t, w.Result().Cookies())
+			assert.Equal(t, "", tokenCookie.Value)
+			assert.Equal(t, "/", tokenCookie.Path)
+			assert.Equal(t, 0, tokenCookie.MaxAge)
+			assert.True(t, tokenCookie.HttpOnly)
+			assert.Equal(t, tc.expectedSecure, tokenCookie.Secure)
+		})
+	}
+}
+
+func TestSignOutHandler_IsIdempotentAcrossRepeatedCalls(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	pkg.App = &pkg.Application{
+		Config: &testConfiguration{
+			securityConfig: &testSecurityConfig{cookieConfig: &testCookieConfig{secure: true}},
+		},
+	}
+
+	router := gin.New()
+	router.POST("/api/v1/auth/sign-out", SignOutHandler)
+
+	firstRequest := httptest.NewRequest(http.MethodPost, "/api/v1/auth/sign-out", nil)
+	firstResponse := httptest.NewRecorder()
+	router.ServeHTTP(firstResponse, firstRequest)
+
+	secondRequest := httptest.NewRequest(http.MethodPost, "/api/v1/auth/sign-out", nil)
+	secondResponse := httptest.NewRecorder()
+	router.ServeHTTP(secondResponse, secondRequest)
+
+	assert.Equal(t, http.StatusNoContent, firstResponse.Code)
+	assert.Empty(t, firstResponse.Body.String())
+	firstTokenCookie := findTokenCookie(t, firstResponse.Result().Cookies())
+	assert.Equal(t, "", firstTokenCookie.Value)
+	assert.Equal(t, "/", firstTokenCookie.Path)
+	assert.Equal(t, 0, firstTokenCookie.MaxAge)
+	assert.True(t, firstTokenCookie.HttpOnly)
+	assert.True(t, firstTokenCookie.Secure)
+
+	assert.Equal(t, http.StatusNoContent, secondResponse.Code)
+	assert.Empty(t, secondResponse.Body.String())
+	secondTokenCookie := findTokenCookie(t, secondResponse.Result().Cookies())
+	assert.Equal(t, "", secondTokenCookie.Value)
+	assert.Equal(t, "/", secondTokenCookie.Path)
+	assert.Equal(t, 0, secondTokenCookie.MaxAge)
+	assert.True(t, secondTokenCookie.HttpOnly)
+	assert.True(t, secondTokenCookie.Secure)
+}
+
+func findTokenCookie(t *testing.T, cookies []*http.Cookie) *http.Cookie {
+	t.Helper()
+	require.NotEmpty(t, cookies)
+
+	for _, cookie := range cookies {
+		if cookie.Name == "token" {
+			return cookie
+		}
+	}
+
+	require.Fail(t, "token cookie was not set")
+	return nil
+}

--- a/openspec/changes/archive/2026-04-25-add-signout-endpoint-parity/apply-progress.md
+++ b/openspec/changes/archive/2026-04-25-add-signout-endpoint-parity/apply-progress.md
@@ -1,0 +1,52 @@
+# Apply Progress: add-signout-endpoint-parity
+
+## Mode
+
+Strict TDD
+
+## Completed Tasks
+
+- [x] 1.1 Update `pkg/application.go` to add `RegisterPOST(path string, handler gin.HandlerFunc)` mirroring existing `RegisterGET` style.
+- [x] 1.2 Extend `pkg/application_test.go` with `TestApplication_RegisterPOST` that registers a POST route and asserts handler execution (`200` + expected response body).
+- [x] 2.1 Create `internal/infrastructure/port/in/signout/routes.go` with `SignOutHandler(*gin.Context)` that always sets `token` cookie clear semantics (`""`, `Max-Age=0`, `Path=/`, `HttpOnly=true`, `Secure` from config) and returns `204` with empty body.
+- [x] 2.2 Keep sign-out handler adapter-only (no domain call, no request payload parsing) so repeated calls stay idempotent and contract-consistent.
+- [x] 3.1 Modify `internal/infrastructure/port/in/server/server.go` to register `POST /api/v1/auth/sign-out` using `app.RegisterPOST` and `signout.SignOutHandler`.
+- [x] 3.2 Add `internal/infrastructure/port/in/server/server_test.go` route wiring coverage that executes `Routes(app)` and verifies `POST /api/v1/auth/sign-out` is reachable (not `404`).
+- [x] 4.1 Create `internal/infrastructure/port/in/signout/routes_test.go` table-driven tests for cookie `Secure` enabled/disabled; assert `204`, empty body, and `token` cookie attributes (`Value=""`, `Path=/`, `MaxAge=0`, `HttpOnly=true`, `Secure` matches config).
+- [x] 4.2 In `internal/infrastructure/port/in/signout/routes_test.go`, add repeated-call test (same client sends sign-out twice) asserting both responses are `204` and both include cookie-clear contract.
+- [x] 4.3 Run `go test ./pkg ./internal/infrastructure/port/in/signout ./internal/infrastructure/port/in/server` and then `go test ./...` to validate parity behavior and avoid regressions.
+
+## TDD Cycle Evidence
+
+| Task | Test File | Layer | Safety Net | RED | GREEN | TRIANGULATE | REFACTOR |
+|------|-----------|-------|------------|-----|-------|-------------|----------|
+| 1.1-1.2 | `pkg/application_test.go` | Unit | ✅ `go test ./pkg -run 'TestApplication_RegisterGET\|TestApplication_RegisterProtectedGET'` | ✅ `TestApplication_RegisterPOST` added first (failed: missing `RegisterPOST`) | ✅ `go test ./pkg -run TestApplication_RegisterPOST` | ✅ Added GET-not-registered case to force POST-only behavior path | ✅ `gofmt` and focused helper-style parity |
+| 2.1-2.2, 4.1-4.2 | `internal/infrastructure/port/in/signout/routes_test.go` | Unit | N/A (new package) | ✅ Added signout tests first (failed: undefined `SignOutHandler`) | ✅ `go test ./internal/infrastructure/port/in/signout -run 'TestSignOutHandler_ClearsTokenCookieAndReturnsNoContent\|TestSignOutHandler_IsIdempotentAcrossRepeatedCalls'` | ✅ Table-driven `Secure` on/off + repeated-call idempotency scenario | ✅ Extracted `findTokenCookie` helper and formatted |
+| 3.1-3.2 | `internal/infrastructure/port/in/server/server_test.go` | Integration | ✅ `go test ./internal/infrastructure/port/in/server` (baseline: no tests, no failures) | ✅ Added route wiring test first (failed 404 before route registration) | ✅ `go test ./internal/infrastructure/port/in/server -run TestRoutes_RegistersSignOutEndpoint` | ➖ Single behavior scenario in spec for wiring reachability | ✅ `gofmt` and minimal fixture setup |
+| 4.3 | N/A (verification command task) | Verification | N/A | ➖ Command-only task | ✅ `go test ./pkg ./internal/infrastructure/port/in/signout ./internal/infrastructure/port/in/server` and `go test ./...` | ➖ Command-only task | ➖ None needed |
+
+## Test Summary
+
+- **Total tests written**: 4
+- **Total tests passing**: 4 new tests + full suite passing
+- **Layers used**: Unit (3 tests), Integration (1 test), E2E (0)
+- **Approval tests**: None — no refactor-only task
+- **Pure functions created**: 1 (`resolveCookieSecure`)
+
+## Files Changed
+
+- `pkg/application.go` — added `RegisterPOST` helper.
+- `pkg/application_test.go` — added TDD coverage for POST registration including method-path differentiation.
+- `internal/infrastructure/port/in/signout/routes.go` — added adapter-only sign-out handler returning `204` and clearing cookie.
+- `internal/infrastructure/port/in/signout/routes_test.go` — added table-driven cookie contract tests and repeated-call idempotency test.
+- `internal/infrastructure/port/in/server/server.go` — wired `POST /api/v1/auth/sign-out` route.
+- `internal/infrastructure/port/in/server/server_test.go` — added route reachability integration test.
+- `openspec/changes/add-signout-endpoint-parity/tasks.md` — marked completed tasks `[x]`.
+
+## Deviations
+
+None — implementation matches spec/design.
+
+## Issues
+
+None.

--- a/openspec/changes/archive/2026-04-25-add-signout-endpoint-parity/archive-report.md
+++ b/openspec/changes/archive/2026-04-25-add-signout-endpoint-parity/archive-report.md
@@ -1,0 +1,46 @@
+# Archive Report: add-signout-endpoint-parity
+
+## Metadata
+
+- Change: `add-signout-endpoint-parity`
+- Date archived: `2026-04-25`
+- Artifact store mode: `hybrid`
+- Archive path: `openspec/changes/archive/2026-04-25-add-signout-endpoint-parity/`
+
+## Engram Artifact Traceability (required dependencies)
+
+- `sdd/add-signout-endpoint-parity/explore` → observation **#112**
+- `sdd/add-signout-endpoint-parity/proposal` → observation **#115**
+- `sdd/add-signout-endpoint-parity/spec` → observation **#117**
+- `sdd/add-signout-endpoint-parity/design` → observation **#118**
+- `sdd/add-signout-endpoint-parity/tasks` → observation **#119**
+- `sdd/add-signout-endpoint-parity/apply-progress` → observation **#121**
+- `sdd/add-signout-endpoint-parity/verify-report` → observation **#123**
+
+## Spec Sync to Source of Truth
+
+| Domain | Action | Details |
+|---|---|---|
+| `auth-signout` | Created | Main spec did not exist; copied delta spec to `openspec/specs/auth-signout/spec.md` as full spec. |
+
+## Archive Move
+
+- Moved active change folder:
+  - From: `openspec/changes/add-signout-endpoint-parity/`
+  - To: `openspec/changes/archive/2026-04-25-add-signout-endpoint-parity/`
+
+## Verification Checklist
+
+- [x] Main specs updated (`openspec/specs/auth-signout/spec.md` exists and contains sign-out requirements)
+- [x] Change folder moved to archive with ISO date prefix
+- [x] Archive contains proposal, specs, design, tasks, apply-progress, and verify-report artifacts
+- [x] Active changes directory no longer contains `add-signout-endpoint-parity`
+- [x] Verification report contains no CRITICAL issues (verdict: PASS WITH WARNINGS)
+
+## Risks
+
+- Non-blocking warning carried from verification: changed-file coverage for `internal/infrastructure/port/in/signout/routes.go` is 72.7% due to untested nil-guard branches in `resolveCookieSecure`.
+
+## Outcome
+
+Change `add-signout-endpoint-parity` is fully archived. Main specs are now source-of-truth aligned, and the full audit trail is preserved in both OpenSpec archive and Engram.

--- a/openspec/changes/archive/2026-04-25-add-signout-endpoint-parity/design.md
+++ b/openspec/changes/archive/2026-04-25-add-signout-endpoint-parity/design.md
@@ -1,0 +1,80 @@
+# Design: Add Sign-Out Endpoint Parity
+
+## Technical Approach
+
+Implement a minimal inbound HTTP addition that follows existing Gin wiring: extend the application wrapper with POST registration, add `POST /api/v1/auth/sign-out` in server route wiring, and implement a small sign-out handler that always responds `204` while clearing the `token` cookie. This keeps handlers thin and matches the current layered flow (`cmd` → `server.Routes` → inbound adapter handler).
+
+## Architecture Decisions
+
+| Option | Tradeoff | Decision |
+|---|---|---|
+| Add `RegisterPOST` to `pkg.Application` | Small wrapper growth, but preserves current abstraction used by route modules | ✅ Chosen |
+| Register POST directly on Gin engine from server module | Less wrapper code, but breaks encapsulation/convention | Rejected |
+
+| Option | Tradeoff | Decision |
+|---|---|---|
+| Keep sign-out endpoint unprotected and always clear cookie | Does not validate token presence, but allows idempotent logout and simpler client behavior | ✅ Chosen |
+| Protect endpoint with auth middleware | Stronger gate, but fails logout when cookie is expired/invalid | Rejected |
+
+| Option | Tradeoff | Decision |
+|---|---|---|
+| Clear cookie via `SetCookie("token", "", 0, "/", "", secureFromConfig, true)` | Keeps parity contract, but hard-codes `HttpOnly=true` at sign-out | ✅ Chosen |
+| Reuse `http-only` config value for clearing | More configurable, but diverges from proposal’s explicit parity/security requirement | Rejected |
+
+## Data Flow
+
+Client `POST /api/v1/auth/sign-out`  
+→ Gin route registered by `server.Routes`  
+→ `signout.SignOutHandler` reads cookie security config (`Secure`)  
+→ sets clearing cookie (`token` empty, `Max-Age=0`, `Path=/`, `HttpOnly=true`)  
+→ returns `204 No Content`.
+
+```
+HTTP Client -> server.Routes -> app.RegisterPOST
+                                |
+                                v
+                       signout.SignOutHandler
+                                |
+                                v
+                       Set-Cookie(token=; Max-Age=0)
+                                + 204
+```
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `pkg/application.go` | Modify | Add `RegisterPOST(path, handler)` helper mirroring existing GET helper style. |
+| `pkg/application_test.go` | Modify | Add coverage that POST registration routes and executes handler correctly. |
+| `internal/infrastructure/port/in/server/server.go` | Modify | Wire `POST /api/v1/auth/sign-out` to sign-out handler. |
+| `internal/infrastructure/port/in/signout/routes.go` | Create | Implement thin sign-out handler with cookie clearing + `204` response. |
+| `internal/infrastructure/port/in/signout/routes_test.go` | Create | Validate status and cookie-clearing contract. |
+| `internal/infrastructure/port/in/server/server_test.go` | Create (optional/minimal) | Verify route is reachable through server wiring (`POST` returns non-404 and expected status). |
+
+## Interfaces / Contracts
+
+```http
+POST /api/v1/auth/sign-out
+Response: 204 No Content
+Headers:
+  Set-Cookie: token=; Max-Age=0; Path=/; HttpOnly; [Secure if configured]
+Body: empty
+```
+
+Handler contract (inbound adapter): no request body, no domain call, deterministic response.
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Unit | Application POST helper works | In `pkg/application_test.go`, register POST test endpoint and assert `200` from recorder. |
+| Unit | Sign-out handler contract | In `signout/routes_test.go`, invoke POST route and assert `204`, empty body, and `token` cookie attributes (`Value=""`, `MaxAge=0`, `Path=/`, `HttpOnly=true`, `Secure` matches config). |
+| Integration | Route wiring parity | In server routing test, execute `server.Routes(app)` and assert `POST /api/v1/auth/sign-out` is registered and returns sign-out response. |
+
+## Migration / Rollout
+
+No migration required. Safe additive API change.
+
+## Open Questions
+
+- [ ] Should server-level route reachability be covered only via sign-out handler test or also by a dedicated `server.Routes` integration test in this repo?

--- a/openspec/changes/archive/2026-04-25-add-signout-endpoint-parity/exploration.md
+++ b/openspec/changes/archive/2026-04-25-add-signout-endpoint-parity/exploration.md
@@ -1,0 +1,39 @@
+## Exploration: add-signout-endpoint-parity
+
+### Current State
+The HTTP server currently registers only GET endpoints via `Application.RegisterGET` and `Application.RegisterProtectedGET`; there is no POST registration helper and no existing sign-out route. Authentication cookie issuance happens in the Google callback handler (`/login/oauth2/code/google`) using `ctx.SetCookie("token", token, maxAge, "/", "", secure, httpOnly)`, where `secure` and `httpOnly` are read from `security.cookie` config. Protected auth functionality currently exposes only `GET /api/v1/auth/me` behind middleware.
+
+### Affected Areas
+- `pkg/application.go` — currently supports only GET route helpers; adding `POST /api/v1/auth/sign-out` likely requires a `RegisterPOST` helper (and optionally protected variant).
+- `internal/infrastructure/port/in/server/server.go` — central route registration point where `/api/v1/auth/sign-out` must be wired.
+- `internal/infrastructure/port/in/google/routes.go` — existing source of truth for token cookie creation behavior; useful to mirror security/cookie behavior expectations.
+- `internal/infrastructure/port/in/google/routes_test.go` — demonstrates current cookie assertions pattern (find `token` cookie and assert attributes/value).
+- `cmd/provider-auth-ms/config.yaml` and `pkg/config-security.go` — define cookie security knobs (`secure`, `http-only`, `max-age`, `same-site`) that sign-out behavior must preserve where applicable.
+- `internal/infrastructure/port/in/.../*_test.go` (new sign-out test file expected) — tests should cover happy path (`204`) and cookie-clearing contract.
+
+### Approaches
+1. **Dedicated sign-out handler + POST route support** — add a focused sign-out inbound handler and register it on `POST /api/v1/auth/sign-out`.
+   - Pros: Clean parity with required endpoint/method, explicit intent, easiest to test at handler level, minimal blast radius.
+   - Cons: Requires small framework extension (`RegisterPOST`) since app wrapper is GET-only today.
+   - Effort: Low.
+
+2. **Register route directly on Gin engine (bypass app wrapper)** — expose/use raw router internals to add POST without extending `Application`.
+   - Pros: No new wrapper method.
+   - Cons: Breaks current abstraction pattern, leaks infrastructure details, creates inconsistency for future endpoints.
+   - Effort: Low/Medium.
+
+3. **Model sign-out as GET (keep existing helpers)** — add sign-out on GET for minimal plumbing.
+   - Pros: No wrapper changes.
+   - Cons: Violates explicit requirement (`POST /api/v1/auth/sign-out`), weaker semantic parity with Java service.
+   - Effort: Low, but not acceptable.
+
+### Recommendation
+Use **Approach 1**: introduce a dedicated sign-out handler and add explicit POST registration support in the `Application` wrapper, then wire `POST /api/v1/auth/sign-out` from `server.Routes`. Implement cookie clearing with `token` cookie, `Max-Age=0`, `Path=/`, and `HttpOnly=true`, while keeping existing security behavior alignment by reusing config-driven fields where expected (notably `Secure`). Add tests validating `204 No Content` and that the response includes a clearing `token` cookie with required attributes.
+
+### Risks
+- **Config vs hard requirement ambiguity**: requirement says `HttpOnly=true`, while config exposes `http-only`; forcing true may diverge from configurable behavior if currently set false in some envs.
+- **Cookie attribute coverage gap**: `same-site` exists in config but is not currently applied through `ctx.SetCookie`; parity expectations should avoid silently introducing behavior not used elsewhere unless explicitly requested.
+- **Routing abstraction change**: adding POST helpers in `pkg.Application` can affect conventions/tests; existing tests currently cover only GET and protected GET registration.
+
+### Ready for Proposal
+Yes — enough context exists to draft proposal/spec/tasks for a small feature change: add POST sign-out endpoint, clear auth cookie with required attributes, and add focused tests for status and cookie clearing behavior.

--- a/openspec/changes/archive/2026-04-25-add-signout-endpoint-parity/proposal.md
+++ b/openspec/changes/archive/2026-04-25-add-signout-endpoint-parity/proposal.md
@@ -1,0 +1,67 @@
+# Proposal: Add Sign-Out Endpoint Parity
+
+## Intent
+
+Close Java/Go parity gap by adding `POST /api/v1/auth/sign-out` so clients can trigger server-driven logout and receive a consistent cookie-clearing response.
+
+## Scope
+
+### In Scope
+- Add POST route registration support in the application wrapper used by HTTP adapters.
+- Add `POST /api/v1/auth/sign-out` route in server wiring and implement a focused sign-out handler.
+- Return `204 No Content` and clear `token` cookie with a consistent contract.
+- Add tests for route reachability, status code, and cookie-clearing behavior.
+
+### Out of Scope
+- Changes to login/token issuance flow.
+- Introducing or changing SameSite/domain cookie behavior beyond current project defaults.
+- Frontend/client logout workflow changes.
+
+## Capabilities
+
+### New Capabilities
+- `auth-signout`: Server endpoint to invalidate session cookie semantics via response cookie expiration.
+
+### Modified Capabilities
+- None.
+
+## Approach
+
+- Extend `pkg/application.go` with POST registration helper(s) consistent with current GET abstractions.
+- Wire `POST /api/v1/auth/sign-out` in `internal/infrastructure/port/in/server/server.go`.
+- Implement sign-out handler under inbound HTTP adapter layer.
+- **Cookie decision (normative):** clear cookie via `SetCookie("token", "", 0, "/", "", secureFromConfig, true)`.
+  - `HttpOnly` is always `true` for sign-out response (explicit parity/security contract).
+  - `Secure` follows existing config behavior.
+  - No new SameSite behavior is introduced in this change.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `pkg/application.go` | Modified | Add POST route helper(s). |
+| `internal/infrastructure/port/in/server/server.go` | Modified | Register `/api/v1/auth/sign-out`. |
+| `internal/infrastructure/port/in/**/routes*.go` | New/Modified | Add sign-out handler and route wiring. |
+| `internal/infrastructure/port/in/**/*_test.go` | New/Modified | Add sign-out contract tests. |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Cookie-attribute mismatch vs expectations | Medium | Lock contract in spec/tests (status + cookie attributes). |
+| Wrapper change affects route conventions | Low | Keep helper shape aligned with existing GET helpers and test wiring. |
+
+## Rollback Plan
+
+Revert POST helper and sign-out route/handler files; remove associated tests; redeploy previous build with unchanged auth behavior.
+
+## Dependencies
+
+- Existing Gin context cookie API and current security config loading.
+
+## Success Criteria
+
+- [ ] `POST /api/v1/auth/sign-out` is reachable in router.
+- [ ] Endpoint returns `204 No Content`.
+- [ ] Response clears `token` cookie (`Max-Age=0`, `Path=/`, `HttpOnly=true`, `Secure` from config).
+- [ ] Automated tests verify status and cookie-clearing contract.

--- a/openspec/changes/archive/2026-04-25-add-signout-endpoint-parity/specs/auth-signout/spec.md
+++ b/openspec/changes/archive/2026-04-25-add-signout-endpoint-parity/specs/auth-signout/spec.md
@@ -1,0 +1,54 @@
+# auth-signout Specification
+
+## Purpose
+
+Define server sign-out behavior parity for `POST /api/v1/auth/sign-out`, including the normative cookie-clearing contract for the auth token cookie.
+
+## Requirements
+
+### Requirement: Sign-out endpoint availability and response
+
+The system MUST expose `POST /api/v1/auth/sign-out` and MUST return `204 No Content` when invoked.
+
+The system MUST treat sign-out as safe to repeat and MUST preserve the same response contract on repeated calls.
+
+#### Scenario: Sign-out endpoint is reachable
+
+- GIVEN the HTTP server is running
+- WHEN a client sends `POST /api/v1/auth/sign-out`
+- THEN the response status is `204 No Content`
+- AND the response body is empty
+
+#### Scenario: Repeated sign-out remains contract-consistent
+
+- GIVEN a client has already called sign-out
+- WHEN the same client sends `POST /api/v1/auth/sign-out` again
+- THEN the response status is `204 No Content`
+- AND the cookie-clearing contract is still applied
+
+### Requirement: Token cookie-clearing contract
+
+The system MUST clear the `token` cookie in the sign-out response by setting a cookie with:
+- `Name=token`
+- `Value=""`
+- `Path=/`
+- `Max-Age=0` (delete semantics)
+- `HttpOnly=true`
+
+The system MUST set the `Secure` attribute according to current runtime security configuration.
+
+The system SHALL NOT introduce new SameSite or Domain behavior as part of this capability.
+
+#### Scenario: Sign-out clears token cookie with delete semantics
+
+- GIVEN a client sends `POST /api/v1/auth/sign-out`
+- WHEN the server builds the response headers
+- THEN `Set-Cookie` includes `token=`, `Path=/`, `Max-Age=0`, and `HttpOnly`
+- AND the cookie represents deletion semantics for `token`
+
+#### Scenario: Secure attribute follows configuration
+
+- GIVEN runtime cookie security configuration is enabled or disabled
+- WHEN a client sends `POST /api/v1/auth/sign-out`
+- THEN the sign-out `Set-Cookie` includes `Secure` when enabled
+- AND omits `Secure` when disabled

--- a/openspec/changes/archive/2026-04-25-add-signout-endpoint-parity/tasks.md
+++ b/openspec/changes/archive/2026-04-25-add-signout-endpoint-parity/tasks.md
@@ -1,0 +1,22 @@
+# Tasks: Add Sign-Out Endpoint Parity
+
+## Phase 1: Foundation
+
+- [x] 1.1 Update `pkg/application.go` to add `RegisterPOST(path string, handler gin.HandlerFunc)` mirroring existing `RegisterGET` style.
+- [x] 1.2 Extend `pkg/application_test.go` with `TestApplication_RegisterPOST` that registers a POST route and asserts handler execution (`200` + expected response body).
+
+## Phase 2: Sign-out Endpoint Implementation
+
+- [x] 2.1 Create `internal/infrastructure/port/in/signout/routes.go` with `SignOutHandler(*gin.Context)` that always sets `token` cookie clear semantics (`""`, `Max-Age=0`, `Path=/`, `HttpOnly=true`, `Secure` from config) and returns `204` with empty body.
+- [x] 2.2 Keep sign-out handler adapter-only (no domain call, no request payload parsing) so repeated calls stay idempotent and contract-consistent.
+
+## Phase 3: HTTP Wiring
+
+- [x] 3.1 Modify `internal/infrastructure/port/in/server/server.go` to register `POST /api/v1/auth/sign-out` using `app.RegisterPOST` and `signout.SignOutHandler`.
+- [x] 3.2 Add `internal/infrastructure/port/in/server/server_test.go` route wiring coverage that executes `Routes(app)` and verifies `POST /api/v1/auth/sign-out` is reachable (not `404`).
+
+## Phase 4: Testing and Verification
+
+- [x] 4.1 Create `internal/infrastructure/port/in/signout/routes_test.go` table-driven tests for cookie `Secure` enabled/disabled; assert `204`, empty body, and `token` cookie attributes (`Value=""`, `Path=/`, `MaxAge=0`, `HttpOnly=true`, `Secure` matches config).
+- [x] 4.2 In `internal/infrastructure/port/in/signout/routes_test.go`, add repeated-call test (same client sends sign-out twice) asserting both responses are `204` and both include cookie-clear contract.
+- [x] 4.3 Run `go test ./pkg ./internal/infrastructure/port/in/signout ./internal/infrastructure/port/in/server` and then `go test ./...` to validate parity behavior and avoid regressions.

--- a/openspec/changes/archive/2026-04-25-add-signout-endpoint-parity/verify-report.md
+++ b/openspec/changes/archive/2026-04-25-add-signout-endpoint-parity/verify-report.md
@@ -1,0 +1,140 @@
+# Verification Report
+
+**Change**: add-signout-endpoint-parity  
+**Version**: N/A  
+**Mode**: Strict TDD
+
+---
+
+### Completeness
+| Metric | Value |
+|--------|-------|
+| Tasks total | 9 |
+| Tasks complete | 9 |
+| Tasks incomplete | 0 |
+
+All tasks are marked complete in `openspec/changes/add-signout-endpoint-parity/tasks.md`.
+
+---
+
+### Build & Tests Execution
+
+**Build**: ✅ Passed
+```text
+go build ./...
+(no output)
+```
+
+**Tests**: ✅ 134 passed / ❌ 0 failed / ⚠️ 0 skipped
+```text
+go test ./...
+PASS (all packages with tests)
+
+Detailed changed-area run:
+go test -v ./pkg ./internal/infrastructure/port/in/signout ./internal/infrastructure/port/in/server
+- TestApplication_RegisterPOST: PASS
+- TestSignOutHandler_ClearsTokenCookieAndReturnsNoContent: PASS
+- TestSignOutHandler_IsIdempotentAcrossRepeatedCalls: PASS
+- TestRoutes_RegistersSignOutEndpoint: PASS
+```
+
+**Coverage**: 85.8% / threshold: N/A → ➖ No configured threshold
+
+---
+
+### TDD Compliance
+| Check | Result | Details |
+|-------|--------|---------|
+| TDD Evidence reported | ✅ | Found `TDD Cycle Evidence` table in `apply-progress.md` |
+| All tasks have tests | ✅ | 3/3 code-change task groups mapped to test files (1 command-only task is N/A) |
+| RED confirmed (tests exist) | ✅ | 3/3 referenced test files exist |
+| GREEN confirmed (tests pass) | ✅ | 3/3 referenced test files pass in current execution |
+| Triangulation adequate | ✅ | Secure on/off table + repeated-call scenario present; wiring has single spec scenario |
+| Safety Net for modified files | ✅ | Modified test file (`pkg/application_test.go`) shows safety net; new files acceptable |
+
+**TDD Compliance**: 6/6 checks passed
+
+---
+
+### Test Layer Distribution
+| Layer | Tests | Files | Tools |
+|-------|-------|-------|-------|
+| Unit | 3 | 2 | `go test` |
+| Integration | 1 | 1 | `go test` + `httptest` |
+| E2E | 0 | 0 | not installed |
+| **Total** | **4** | **3** | |
+
+---
+
+### Changed File Coverage
+| File | Line % | Branch % | Uncovered Lines | Rating |
+|------|--------|----------|-----------------|--------|
+| `pkg/application.go` | 100.0% | N/A | — | ✅ Excellent |
+| `internal/infrastructure/port/in/signout/routes.go` | 72.7% | N/A | L16-L18, L21-L23, L26-L28 | ⚠️ Low |
+| `internal/infrastructure/port/in/server/server.go` | 100.0% | N/A | — | ✅ Excellent |
+
+**Average changed file coverage**: 90.9%  
+**Total uncovered lines in changed files**: 9
+
+---
+
+### Assertion Quality
+
+**Assertion quality**: ✅ All assertions verify real behavior
+
+---
+
+### Quality Metrics
+**Linter**: ➖ Not available  
+**Type Checker**: ✅ `go vet ./...` no errors
+
+---
+
+### Spec Compliance Matrix
+
+| Requirement | Scenario | Test | Result |
+|-------------|----------|------|--------|
+| Sign-out endpoint availability and response | Sign-out endpoint is reachable | `internal/infrastructure/port/in/server/server_test.go > TestRoutes_RegistersSignOutEndpoint` | ✅ COMPLIANT |
+| Sign-out endpoint availability and response | Repeated sign-out remains contract-consistent | `internal/infrastructure/port/in/signout/routes_test.go > TestSignOutHandler_IsIdempotentAcrossRepeatedCalls` | ✅ COMPLIANT |
+| Token cookie-clearing contract | Sign-out clears token cookie with delete semantics | `internal/infrastructure/port/in/signout/routes_test.go > TestSignOutHandler_ClearsTokenCookieAndReturnsNoContent` | ✅ COMPLIANT |
+| Token cookie-clearing contract | Secure attribute follows configuration | `internal/infrastructure/port/in/signout/routes_test.go > TestSignOutHandler_ClearsTokenCookieAndReturnsNoContent/{secure cookie disabled, secure cookie enabled}` | ✅ COMPLIANT |
+
+**Compliance summary**: 4/4 scenarios compliant
+
+---
+
+### Correctness (Static — Structural Evidence)
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| Sign-out endpoint availability and response | ✅ Implemented | `server.Routes` registers POST sign-out; handler returns `204` with empty body; repeated-call behavior tested |
+| Token cookie-clearing contract | ✅ Implemented | `SignOutHandler` sets `token` cookie clear semantics (`""`, `Path=/`, `Max-Age=0`, `HttpOnly=true`, config-driven `Secure`) with no SameSite/Domain additions |
+
+---
+
+### Coherence (Design)
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| Add `RegisterPOST` to `pkg.Application` | ✅ Yes | `pkg/application.go` adds `RegisterPOST` mirroring GET style |
+| Keep sign-out unprotected and idempotent | ✅ Yes | Route is unprotected; handler has no auth/domain dependency and deterministic `204` |
+| Clear cookie with explicit `HttpOnly=true` and config-driven `Secure` | ✅ Yes | `ctx.SetCookie("token", "", 0, "/", "", resolveCookieSecure(), true)` |
+| File changes align with design file table | ✅ Yes | All listed files present and implemented per design |
+
+---
+
+### Issues Found
+
+**CRITICAL** (must fix before archive):
+- None.
+
+**WARNING** (should fix):
+- `internal/infrastructure/port/in/signout/routes.go` changed-file coverage is 72.7% (<80%). Nil-guard branches in `resolveCookieSecure` (L16-L18, L21-L23, L26-L28) are not exercised by tests.
+
+**SUGGESTION** (nice to have):
+- Add explicit branch tests for `resolveCookieSecure` fallback paths (`pkg.App == nil`, `SecurityConfig == nil`, `CookieConfig == nil`) to improve robustness evidence.
+
+---
+
+### Verdict
+PASS WITH WARNINGS
+
+Implementation is behaviorally compliant with the spec and design, with one non-blocking coverage warning on fallback branches.

--- a/openspec/specs/auth-signout/spec.md
+++ b/openspec/specs/auth-signout/spec.md
@@ -1,0 +1,54 @@
+# auth-signout Specification
+
+## Purpose
+
+Define server sign-out behavior parity for `POST /api/v1/auth/sign-out`, including the normative cookie-clearing contract for the auth token cookie.
+
+## Requirements
+
+### Requirement: Sign-out endpoint availability and response
+
+The system MUST expose `POST /api/v1/auth/sign-out` and MUST return `204 No Content` when invoked.
+
+The system MUST treat sign-out as safe to repeat and MUST preserve the same response contract on repeated calls.
+
+#### Scenario: Sign-out endpoint is reachable
+
+- GIVEN the HTTP server is running
+- WHEN a client sends `POST /api/v1/auth/sign-out`
+- THEN the response status is `204 No Content`
+- AND the response body is empty
+
+#### Scenario: Repeated sign-out remains contract-consistent
+
+- GIVEN a client has already called sign-out
+- WHEN the same client sends `POST /api/v1/auth/sign-out` again
+- THEN the response status is `204 No Content`
+- AND the cookie-clearing contract is still applied
+
+### Requirement: Token cookie-clearing contract
+
+The system MUST clear the `token` cookie in the sign-out response by setting a cookie with:
+- `Name=token`
+- `Value=""`
+- `Path=/`
+- `Max-Age=0` (delete semantics)
+- `HttpOnly=true`
+
+The system MUST set the `Secure` attribute according to current runtime security configuration.
+
+The system SHALL NOT introduce new SameSite or Domain behavior as part of this capability.
+
+#### Scenario: Sign-out clears token cookie with delete semantics
+
+- GIVEN a client sends `POST /api/v1/auth/sign-out`
+- WHEN the server builds the response headers
+- THEN `Set-Cookie` includes `token=`, `Path=/`, `Max-Age=0`, and `HttpOnly`
+- AND the cookie represents deletion semantics for `token`
+
+#### Scenario: Secure attribute follows configuration
+
+- GIVEN runtime cookie security configuration is enabled or disabled
+- WHEN a client sends `POST /api/v1/auth/sign-out`
+- THEN the sign-out `Set-Cookie` includes `Secure` when enabled
+- AND omits `Secure` when disabled

--- a/pkg/application.go
+++ b/pkg/application.go
@@ -47,6 +47,10 @@ func (app *Application) RegisterGET(path string, handler gin.HandlerFunc) {
 	app.handler.GET(path, handler)
 }
 
+func (app *Application) RegisterPOST(path string, handler gin.HandlerFunc) {
+	app.handler.POST(path, handler)
+}
+
 func (app *Application) RegisterProtectedGET(path string, handler gin.HandlerFunc) {
 	app.handler.GET(path, app.AuthMiddleware(), handler)
 }

--- a/pkg/application_test.go
+++ b/pkg/application_test.go
@@ -133,6 +133,40 @@ func TestApplication_RegisterGET(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "test")
 }
 
+func TestApplication_RegisterPOST(t *testing.T) {
+	cleanup := createTestConfig(t)
+	defer cleanup()
+
+	gin.SetMode(gin.TestMode)
+
+	app := &Application{}
+	app.UseConfig()
+	app.UseServer()
+
+	handler := func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"message": "created"})
+	}
+
+	app.RegisterPOST("/test", handler)
+
+	t.Run("post route executes handler", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodPost, "/test", nil)
+		app.Server.Handler.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "created")
+	})
+
+	t.Run("get route is not registered", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/test", nil)
+		app.Server.Handler.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+}
+
 func TestApplication_RegisterProtectedGET(t *testing.T) {
 	cleanup := createTestConfig(t)
 	defer cleanup()


### PR DESCRIPTION
Closes #1

## Summary
- Add Java parity endpoint `POST /api/v1/auth/sign-out` to clear auth session cookie.
- Introduce `RegisterPOST` in application routing wrapper and wire sign-out route in server bootstrap.
- Add unit/integration tests for route registration, 204 response, cookie-clearing contract, and idempotent repeated sign-out calls.

## Changes
| File | Change |
|------|--------|
| `pkg/application.go` | Added `RegisterPOST(path, handler)` helper to expose POST route registration through app wrapper. |
| `pkg/application_test.go` | Added `TestApplication_RegisterPOST` to verify POST registration behavior and GET non-registration. |
| `internal/infrastructure/port/in/server/server.go` | Registered `POST /api/v1/auth/sign-out` route. |
| `internal/infrastructure/port/in/server/server_test.go` | Added server-level reachability test for sign-out endpoint. |
| `internal/infrastructure/port/in/signout/routes.go` | Implemented sign-out handler that clears `token` cookie and returns `204 No Content`. |
| `internal/infrastructure/port/in/signout/routes_test.go` | Added behavior tests for cookie clearing and repeated-call idempotency. |
| `openspec/specs/auth-signout/spec.md` | Added archived source-of-truth spec for sign-out behavior contract. |
| `openspec/changes/archive/2026-04-25-add-signout-endpoint-parity/*` | Added archived SDD hybrid artifacts (explore/proposal/design/tasks/apply/verify/archive report). |
| `.gitignore` | Ignored generated `test-report.json`. |

## Test Plan
- [x] `go test ./...`

## Checklist
- [x] Linked approved issue
- [x] Added exactly one `type:*` label (pending add via CLI after PR create)
- [x] Conventional commits used
- [x] Documentation/spec artifacts updated for behavior change