### PR TITLE
fix: apply configured SameSite policy to callback token cookie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ go.work.sum
 .vscode/
 .atl/
 test-report.json
+test-results.json

--- a/internal/infrastructure/port/in/google/routes.go
+++ b/internal/infrastructure/port/in/google/routes.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/matiasmartin-labs/auth-provider-ms/internal/application/ports"
@@ -25,6 +26,19 @@ type GoogleOAuth2Handler interface {
 type googleOAuth2HandlerImpl struct {
 	providerRepository ports.ProviderRepository
 	tokenGenerator     ports.TokenGenerator
+}
+
+func parseSameSite(raw string) http.SameSite {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "strict":
+		return http.SameSiteStrictMode
+	case "lax":
+		return http.SameSiteLaxMode
+	case "none":
+		return http.SameSiteNoneMode
+	default:
+		return http.SameSite(0)
+	}
 }
 
 func NewGoogleOAuth2Handler(providerRepository ports.ProviderRepository, tokenGenerator ports.TokenGenerator) GoogleOAuth2Handler {
@@ -77,15 +91,15 @@ func (h *googleOAuth2HandlerImpl) GoogleCallbackHandler(ctx *gin.Context) {
 
 	securityCfg := pkg.App.Config.GetSecurityConfig()
 	cookieCfg := securityCfg.GetCookieConfig()
-	ctx.SetCookie(
-		"token",
-		token,
-		int(cookieCfg.GetMaxAge().Seconds()),
-		"/",
-		"",
-		cookieCfg.GetSecure(),
-		cookieCfg.GetHTTPOnly(),
-	)
+	http.SetCookie(ctx.Writer, &http.Cookie{
+		Name:     "token",
+		Value:    token,
+		Path:     "/",
+		MaxAge:   int(cookieCfg.GetMaxAge().Seconds()),
+		Secure:   cookieCfg.GetSecure(),
+		HttpOnly: cookieCfg.GetHTTPOnly(),
+		SameSite: parseSameSite(cookieCfg.GetSameSite()),
+	})
 	redirectCfg := securityCfg.GetRedirectConfig()
 	if redirectCfg.GetEnabled() {
 		ctx.Redirect(http.StatusTemporaryRedirect, redirectCfg.GetURL())

--- a/internal/infrastructure/port/in/google/routes_test.go
+++ b/internal/infrastructure/port/in/google/routes_test.go
@@ -124,7 +124,16 @@ type mockConfiguration struct {
 func (m *mockConfiguration) GetServerConfig() pkg.ServerConfig     { return nil }
 func (m *mockConfiguration) GetSecurityConfig() pkg.SecurityConfig { return m.securityConfig }
 
-func setupMockApp(state string, allowedEmails []string, redirectEnabled bool, redirectURL string) {
+func setupMockAppWithCookie(state string, allowedEmails []string, redirectEnabled bool, redirectURL string, cookieCfg *mockCookieConfig) {
+	if cookieCfg == nil {
+		cookieCfg = &mockCookieConfig{
+			secure:   false,
+			httpOnly: true,
+			sameSite: "Strict",
+			maxAge:   time.Hour,
+		}
+	}
+
 	pkg.App = &pkg.Application{
 		Config: &mockConfiguration{
 			securityConfig: &mockSecurityConfig{
@@ -139,12 +148,7 @@ func setupMockApp(state string, allowedEmails []string, redirectEnabled bool, re
 					enabled: redirectEnabled,
 					url:     redirectURL,
 				},
-				cookieConfig: &mockCookieConfig{
-					secure:   false,
-					httpOnly: true,
-					sameSite: "Strict",
-					maxAge:   time.Hour,
-				},
+				cookieConfig: cookieCfg,
 				loginConfig: &mockLoginConfig{
 					allowedEmails: allowedEmails,
 				},
@@ -157,6 +161,30 @@ func setupMockApp(state string, allowedEmails []string, redirectEnabled bool, re
 		ClientSecret: "test-secret",
 		RedirectURL:  "http://localhost:8080/callback",
 		Scopes:       []string{"email", "profile"},
+	}
+}
+
+func setupMockApp(state string, allowedEmails []string, redirectEnabled bool, redirectURL string) {
+	setupMockAppWithCookie(state, allowedEmails, redirectEnabled, redirectURL, nil)
+}
+
+func TestParseSameSite(t *testing.T) {
+	testCases := []struct {
+		name     string
+		raw      string
+		expected http.SameSite
+	}{
+		{name: "strict mixed case with spaces", raw: "  sTRicT  ", expected: http.SameSiteStrictMode},
+		{name: "lax mixed case", raw: "LaX", expected: http.SameSiteLaxMode},
+		{name: "none mixed case", raw: "nOnE", expected: http.SameSiteNoneMode},
+		{name: "empty returns omitted mode", raw: "", expected: http.SameSite(0)},
+		{name: "invalid returns omitted mode", raw: "unsupported", expected: http.SameSite(0)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, parseSameSite(tc.raw))
+		})
 	}
 }
 
@@ -359,6 +387,66 @@ func TestGoogleCallbackHandler_Success_WithRedirect(t *testing.T) {
 
 	assert.Equal(t, http.StatusTemporaryRedirect, w.Code)
 	assert.Equal(t, "http://localhost:3000/dashboard", w.Header().Get("Location"))
+}
+
+func TestGoogleCallbackHandler_Success_SameSiteMapping(t *testing.T) {
+	testCases := []struct {
+		name               string
+		sameSite           string
+		expectedSameSite   string
+		expectSameSiteAttr bool
+	}{
+		{name: "strict mixed case", sameSite: "sTRicT", expectedSameSite: "SameSite=Strict", expectSameSiteAttr: true},
+		{name: "lax mixed case", sameSite: "laX", expectedSameSite: "SameSite=Lax", expectSameSiteAttr: true},
+		{name: "none mixed case", sameSite: "NoNe", expectedSameSite: "SameSite=None", expectSameSiteAttr: true},
+		{name: "empty fallback omits samesite", sameSite: "", expectSameSiteAttr: false},
+		{name: "invalid fallback omits samesite", sameSite: "unsupported", expectSameSiteAttr: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			setupMockAppWithCookie("valid-state", []string{"test@example.com"}, false, "", &mockCookieConfig{
+				secure:   true,
+				httpOnly: true,
+				sameSite: tc.sameSite,
+				maxAge:   time.Hour,
+			})
+
+			mockProvider := &mockProviderRepository{
+				userInfo: &model.UserInfo{
+					Email:     "test@example.com",
+					FirstName: "Test",
+					LastName:  "User",
+				},
+				err: nil,
+			}
+			mockToken := &mockTokenGenerator{token: "generated-jwt-token", err: nil}
+			handler := NewGoogleOAuth2Handler(mockProvider, mockToken)
+
+			router := gin.New()
+			router.GET("/callback", handler.GoogleCallbackHandler)
+
+			req := httptest.NewRequest(http.MethodGet, "/callback?state=valid-state&code=test-code", nil)
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+
+			setCookieHeader := w.Header().Get("Set-Cookie")
+			assert.Contains(t, setCookieHeader, "token=generated-jwt-token")
+			assert.Contains(t, setCookieHeader, "Path=/")
+			assert.Contains(t, setCookieHeader, "Max-Age=3600")
+			assert.Contains(t, setCookieHeader, "HttpOnly")
+			assert.Contains(t, setCookieHeader, "Secure")
+
+			if tc.expectSameSiteAttr {
+				assert.Contains(t, setCookieHeader, tc.expectedSameSite)
+			} else {
+				assert.NotContains(t, setCookieHeader, "SameSite")
+			}
+		})
+	}
 }
 
 func TestGoogleLoginHandler_Redirect(t *testing.T) {

--- a/openspec/changes/archive/2026-04-25-issue-3-cookie-samesite/apply-progress.md
+++ b/openspec/changes/archive/2026-04-25-issue-3-cookie-samesite/apply-progress.md
@@ -1,0 +1,50 @@
+# Apply Progress: issue-3-cookie-samesite
+
+## Mode
+
+Strict TDD
+
+## Completed Tasks
+
+- [x] 1.1 Add SameSite parsing helper in `internal/infrastructure/port/in/google/routes.go` using trimmed, case-insensitive mapping for `Strict|Lax|None` with zero-value fallback.
+- [x] 1.2 Refactor callback cookie emission in `GoogleCallbackHandler` to use `http.SetCookie` with explicit `http.Cookie` fields and parsed SameSite while preserving name/path/value/MaxAge/HttpOnly/Secure behavior.
+- [x] 2.1 Ensure callback success flow still follows existing redirect/JSON behavior after cookie write changes.
+- [x] 2.2 Keep sign-out and non-callback cookie code paths unchanged (no shared abstraction scope creep).
+- [x] 3.1 Add table-driven subtests for callback success asserting `SameSite=Strict|Lax|None` from mixed-cased config values.
+- [x] 3.2 Add table-driven subtests for empty and invalid `security.cookie.same-site` asserting `Set-Cookie` omits `SameSite`.
+- [x] 3.3 Add regression assertions for `Secure`, `HttpOnly`, and `Max-Age` for valid and fallback SameSite paths.
+- [x] 3.4 Re-run existing callback branch tests (invalid state, missing code, provider error, token error, email not allowed, redirect/no-redirect success).
+- [x] 4.1 Run `go test ./internal/infrastructure/port/in/google -v`.
+- [x] 4.2 Run `go test ./...`.
+
+## TDD Cycle Evidence
+
+| Task | Test File | Layer | Safety Net | RED | GREEN | TRIANGULATE | REFACTOR |
+|------|-----------|-------|------------|-----|-------|-------------|----------|
+| 1.1 | `internal/infrastructure/port/in/google/routes_test.go` | Unit | ✅ `go test ./internal/infrastructure/port/in/google -count=1` baseline passing | ✅ `TestParseSameSite` written first; failed with `undefined: parseSameSite` | ✅ `go test ./internal/infrastructure/port/in/google -run TestParseSameSite -count=1` | ✅ 5 cases (`Strict`,`Lax`,`None`, empty, invalid) | ✅ `gofmt` after implementation |
+| 1.2, 2.1, 2.2, 3.1, 3.2, 3.3 | `internal/infrastructure/port/in/google/routes_test.go` | Unit/Handler | ✅ Baseline already captured on same package | ✅ `TestGoogleCallbackHandler_Success_SameSiteMapping` added before cookie refactor; initial RED gated by missing parser/behavior | ✅ `go test ./internal/infrastructure/port/in/google -run TestGoogleCallbackHandler_Success_SameSiteMapping -count=1` | ✅ Table-driven with 5 scenarios incl. fallback paths; assertions include cookie security attrs | ✅ kept patch handler-local and formatted |
+| 3.4 | Existing tests in `routes_test.go` | Unit/Handler regression | ✅ Existing tests already green before edits | ✅ N/A (verification task) | ✅ `go test ./internal/infrastructure/port/in/google -run 'TestGoogleCallbackHandler' -count=1` | ➖ Verification-only task | ➖ None needed |
+| 4.1 | Package suite | Verification | N/A | ➖ Command-only task | ✅ `go test ./internal/infrastructure/port/in/google -v -count=1` | ➖ Command-only task | ➖ None needed |
+| 4.2 | Repo suite | Verification | N/A | ➖ Command-only task | ✅ `go test ./... -count=1` | ➖ Command-only task | ➖ None needed |
+
+## Test Summary
+
+- **Total tests written**: 2 new tests (`TestParseSameSite`, `TestGoogleCallbackHandler_Success_SameSiteMapping`)
+- **Total tests passing**: all tests in modified package and full repository suite
+- **Layers used**: Unit/Handler
+- **Approval tests**: None — no refactor-only behavior-preservation task
+- **Pure functions created**: 1 (`parseSameSite`)
+
+## Files Changed
+
+- `internal/infrastructure/port/in/google/routes.go` — added `parseSameSite` and switched callback cookie write to explicit `http.SetCookie` with SameSite mapping.
+- `internal/infrastructure/port/in/google/routes_test.go` — added table-driven SameSite parser and callback header tests; added configurable cookie setup helper to support scenarios.
+- `openspec/changes/issue-3-cookie-samesite/tasks.md` — marked all tasks complete.
+
+## Deviations
+
+None — implementation matches design/spec and remains handler-local.
+
+## Issues
+
+None.

--- a/openspec/changes/archive/2026-04-25-issue-3-cookie-samesite/archive-report.md
+++ b/openspec/changes/archive/2026-04-25-issue-3-cookie-samesite/archive-report.md
@@ -1,0 +1,55 @@
+# Archive Report
+
+**Change**: `issue-3-cookie-samesite`  
+**Project**: `auth-provider-ms`  
+**Mode**: `hybrid`  
+**Archived at**: `2026-04-25`
+
+## Backend Artifact Traceability (Engram)
+
+- Proposal: `sdd/issue-3-cookie-samesite/proposal` → observation **#130**
+- Spec: `sdd/issue-3-cookie-samesite/spec` → observation **#132**
+- Design: `sdd/issue-3-cookie-samesite/design` → observation **#135**
+- Tasks: `sdd/issue-3-cookie-samesite/tasks` → observation **#136**
+- Verify report: `sdd/issue-3-cookie-samesite/verify-report` → observation **#141**
+
+## Archive Preconditions
+
+- Verification report verdict: **PASS**
+- CRITICAL issues in verify report: **None**
+- Tasks complete: **10/10**
+
+## Spec Sync Summary
+
+| Domain | Action | Details |
+|---|---|---|
+| `google-oauth-callback` | Updated | Merged delta requirements into `openspec/specs/google-oauth-callback/spec.md`: **3 added**, **0 modified**, **0 removed** |
+
+Merged requirements:
+1. Callback Token Cookie Applies Configured SameSite Modes
+2. Callback Token Cookie Has Deterministic SameSite Fallback
+3. Existing Callback Cookie Security Attributes Are Preserved
+
+## Filesystem Archive Actions
+
+- Updated source-of-truth spec:
+  - `openspec/specs/google-oauth-callback/spec.md`
+- Moved change directory:
+  - From: `openspec/changes/issue-3-cookie-samesite/`
+  - To: `openspec/changes/archive/2026-04-25-issue-3-cookie-samesite/`
+
+## Archive Verification Checklist
+
+- [x] Main specs updated correctly
+- [x] Change folder moved to dated archive path
+- [x] Archive contains artifacts: proposal/spec/design/tasks/verify (+ exploration/apply-progress)
+- [x] Active changes no longer include `issue-3-cookie-samesite`
+- [x] Backend references (Engram IDs) recorded for full audit traceability
+
+## Source of Truth Updated
+
+- `openspec/specs/google-oauth-callback/spec.md`
+
+## Completion
+
+The `issue-3-cookie-samesite` SDD cycle is fully archived: delta spec synchronized into main spec, change folder moved to archive, and archive traceability persisted to Engram.

--- a/openspec/changes/archive/2026-04-25-issue-3-cookie-samesite/design.md
+++ b/openspec/changes/archive/2026-04-25-issue-3-cookie-samesite/design.md
@@ -1,0 +1,76 @@
+# Design: Apply SameSite on Google Callback Token Cookie
+
+## Technical Approach
+
+Implement a minimal-risk, handler-local change in `GoogleCallbackHandler` to set the token cookie with `http.SetCookie` and explicit `SameSite` mapping from `security.cookie.same-site`.
+
+This preserves current callback flow, keeps existing cookie attributes (`Secure`, `HttpOnly`, `Max-Age`, path/name/value) unchanged, and avoids introducing shared cookie abstractions for this targeted fix.
+
+## Architecture Decisions
+
+| Option | Tradeoff | Decision |
+|---|---|---|
+| Map SameSite in `google/routes.go` and emit cookie with `http.SetCookie` | Smallest blast radius; one handler diverges from `ctx.SetCookie` style | ✅ Chosen |
+| Add shared cookie utility used by callback + signout | Better reuse, but larger refactor and out-of-scope risk | ❌ Rejected |
+| Global Set-Cookie middleware mutation | Centralized policy, but opaque behavior and high regression risk | ❌ Rejected |
+
+| Mapping fallback strategy | Tradeoff | Decision |
+|---|---|---|
+| Invalid/empty config maps to zero-value `http.SameSite` (omit attribute) | Keeps backward-compatible behavior and avoids ambiguous `SameSite` token serialization | ✅ Chosen |
+| Invalid/empty maps to `http.SameSiteDefaultMode` | May serialize as bare `SameSite` token depending on Go behavior; can alter existing header contract | ❌ Rejected |
+
+## Data Flow
+
+```
+GET /login/oauth2/code/google
+  -> validate state/code
+  -> ProviderRepository.GetUserInfo
+  -> UserInfo.IsEmailAllowed
+  -> TokenGenerator.GenerateToken
+  -> cookieCfg.GetSameSite() --(normalize/validate)-> http.SameSite
+  -> http.SetCookie(writer, token cookie)
+  -> redirect (307) OR JSON 200
+```
+
+SameSite normalization rules (case-insensitive, trimmed):
+- `Strict` -> `http.SameSiteStrictMode`
+- `Lax` -> `http.SameSiteLaxMode`
+- `None` -> `http.SameSiteNoneMode`
+- Any other value / empty -> omit SameSite attribute
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `internal/infrastructure/port/in/google/routes.go` | Modify | Replace `ctx.SetCookie` call with explicit `http.Cookie` + SameSite mapping helper local to package/file. |
+| `internal/infrastructure/port/in/google/routes_test.go` | Modify | Add table-driven callback success tests asserting SameSite mapping and fallback behavior from `Set-Cookie`; keep existing branch tests passing. |
+
+## Interfaces / Contracts
+
+No exported interface changes (`pkg.CookieConfig` already exposes `GetSameSite() string`).
+
+Internal helper contract (non-exported):
+
+```go
+func parseSameSite(raw string) http.SameSite
+```
+
+HTTP contract update for callback cookie:
+- `Set-Cookie: token=...` now includes `SameSite=Strict|Lax|None` when configured accordingly.
+- Invalid/empty config keeps prior behavior by not emitting a SameSite attribute.
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Unit/Handler | SameSite mapping (`Strict`, `Lax`, `None`, invalid, empty) | Table-driven subtests in `routes_test.go`; inspect `w.Result().Cookies()` and raw `Set-Cookie` header for attribute presence/absence. |
+| Unit/Handler | Non-regression for existing cookie attrs | Assert token cookie still sets `HttpOnly`, configured `Secure`, and expected `MaxAge`; keep name/path/value unchanged. |
+| Unit/Handler | Existing callback behavior unaffected | Re-run existing tests for invalid state, missing code, provider/token errors, email-not-allowed, redirect/no-redirect success. |
+
+## Migration / Rollout
+
+No migration required. Rollout is immediate on deploy. No feature flag required due to localized change.
+
+## Open Questions
+
+- [ ] Should signout cookie emission also adopt explicit SameSite handling in a separate follow-up change for symmetry?

--- a/openspec/changes/archive/2026-04-25-issue-3-cookie-samesite/exploration.md
+++ b/openspec/changes/archive/2026-04-25-issue-3-cookie-samesite/exploration.md
@@ -1,0 +1,38 @@
+## Exploration: apply configured cookie SameSite policy when setting auth token
+
+### Current State
+`same-site` is already present in runtime config (`security.cookie.same-site`) and exposed through `CookieConfig.GetSameSite()`, but the auth token cookie path (`GoogleCallbackHandler`) currently uses `gin.Context.SetCookie(...)`, which does not apply SameSite from config in the current implementation. As a result, issued auth token cookies include max-age/secure/http-only but not config-driven SameSite.
+
+### Affected Areas
+- `internal/infrastructure/port/in/google/routes.go` — token cookie is set here; current `ctx.SetCookie(...)` call is the behavior gap.
+- `internal/infrastructure/port/in/google/routes_test.go` — tests currently validate token presence/redirect flow but do not assert Set-Cookie SameSite variants.
+- `pkg/config-security.go` — `CookieConfig` already exposes `GetSameSite()` and mapstructure binding for `same-site`.
+- `cmd/provider-auth-ms/config.yaml` — default config includes `same-site: Strict` and serves as documented runtime input.
+- `pkg/config_test.go`, `pkg/application_test.go` — fixture configs already include `same-site`, confirming config ingestion path.
+
+### Approaches
+1. **Handler-local explicit cookie write (recommended)** — build an `http.Cookie` in `GoogleCallbackHandler` and call `http.SetCookie(ctx.Writer, cookie)` with mapped SameSite.
+   - Pros: Minimal surface area; preserves existing control flow; straightforward to test via `Set-Cookie` header; lowest regression risk.
+   - Cons: Cookie write path in this handler diverges from `ctx.SetCookie` style.
+   - Effort: Low.
+
+2. **Shared cookie utility/helper** — introduce a helper that sets token cookie with mapped SameSite and call it from handler(s).
+   - Pros: Reusable and centralizes parsing/mapping rules.
+   - Cons: Slightly larger refactor for a small fix; potentially touches signout/other routes unnecessarily.
+   - Effort: Medium.
+
+3. **Global/middleware Set-Cookie mutation** — post-process headers to inject SameSite globally.
+   - Pros: Centralized policy.
+   - Cons: High risk, opaque behavior, can affect unrelated cookies and ordering; hardest to reason about.
+   - Effort: High.
+
+### Recommendation
+Use **Approach 1**: apply SameSite directly in `GoogleCallbackHandler` by switching only this token cookie write to `http.SetCookie` and mapping config string to `http.SameSite` (`Strict`, `Lax`, `None`, case-insensitive). For invalid/empty values, set `SameSiteDefaultMode`/omit explicit SameSite attribute (documented behavior) so existing behavior remains stable and predictable.
+
+### Risks
+- **Behavioral ambiguity for invalid/empty values**: must be explicitly documented and tested; otherwise behavior can differ across clients.
+- **`SameSite=None` browser expectations**: many browsers require `Secure` for `None`; current acceptance does not require enforcement, but this should be called out.
+- **Regression on existing cookie attributes**: secure/httpOnly/max-age must remain byte-for-byte compatible in header assertions.
+
+### Ready for Proposal
+Yes — scope is clear, impact is localized, and tests can be added to prove supported SameSite modes plus no regression in secure/httpOnly/max-age behavior.

--- a/openspec/changes/archive/2026-04-25-issue-3-cookie-samesite/proposal.md
+++ b/openspec/changes/archive/2026-04-25-issue-3-cookie-samesite/proposal.md
@@ -1,0 +1,60 @@
+# Proposal: Apply configured SameSite on Google callback token cookie
+
+## Intent
+
+Ensure the auth token cookie set during Google OAuth callback honors `security.cookie.same-site`, closing a security/configuration gap where SameSite is currently not applied.
+
+## Scope
+
+### In Scope
+- Update Google callback cookie-writing logic to map config `same-site` (`Strict`, `Lax`, `None`, case-insensitive) to HTTP cookie SameSite.
+- Document and preserve behavior for invalid or empty `same-site` values (default/omitted SameSite attribute).
+- Add/adjust tests to verify `Set-Cookie` SameSite behavior for supported modes and invalid/empty inputs.
+- Guard against regressions in `Secure`, `HttpOnly`, and `Max-Age` cookie attributes.
+
+### Out of Scope
+- Changing sign-out cookie behavior or introducing new sign-out SameSite rules.
+- Enforcing extra policy for `SameSite=None` beyond existing `Secure` behavior.
+- Refactoring all cookie writes into a shared utility.
+
+## Capabilities
+
+### New Capabilities
+None.
+
+### Modified Capabilities
+- `google-oauth-callback`: callback token cookie contract now includes config-driven SameSite behavior and explicit fallback semantics for invalid/empty values.
+
+## Approach
+
+Use a handler-local cookie write in `GoogleCallbackHandler` with `http.SetCookie` and explicit SameSite mapping from `CookieConfig.GetSameSite()`. Keep logic simple with early returns, preserve current cookie fields, and verify via header-level tests.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `internal/infrastructure/port/in/google/routes.go` | Modified | Set callback token cookie via explicit `http.Cookie` with mapped SameSite. |
+| `internal/infrastructure/port/in/google/routes_test.go` | Modified | Add table-driven assertions for `Set-Cookie` SameSite modes and fallback behavior. |
+| `openspec/changes/issue-3-cookie-samesite/specs/google-oauth-callback/spec.md` | New (next phase) | Delta spec for updated cookie SameSite contract. |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Invalid/empty config interpretation mismatch | Med | Specify fallback semantics in specs/tests and assert header output. |
+| `SameSite=None` client expectations vary | Low | Document non-goal and keep `Secure` behavior unchanged. |
+| Cookie attribute regression | Low | Add explicit regression assertions for `Secure`/`HttpOnly`/`Max-Age`. |
+
+## Rollback Plan
+
+Revert callback cookie write to prior `ctx.SetCookie(...)` path and remove SameSite-specific tests; this restores previous runtime behavior immediately without schema/config changes.
+
+## Dependencies
+
+- Existing `security.cookie.same-site` config ingestion via `pkg/config-security.go`.
+
+## Success Criteria
+
+- [ ] Callback `Set-Cookie` reflects configured SameSite for `Strict`, `Lax`, and `None`.
+- [ ] Invalid/empty `same-site` behavior is documented and validated by tests.
+- [ ] Callback cookie `Secure`, `HttpOnly`, and `Max-Age` behavior remains unchanged.

--- a/openspec/changes/archive/2026-04-25-issue-3-cookie-samesite/spec.md
+++ b/openspec/changes/archive/2026-04-25-issue-3-cookie-samesite/spec.md
@@ -1,50 +1,6 @@
-# Google OAuth Callback Specification
+# Delta for google-oauth-callback
 
-## Purpose
-
-Define callback response behavior for allowed and disallowed Google-authenticated emails, aligning disallowed-email handling to `401 Unauthorized` while preserving successful login behavior.
-
-## Requirements
-
-### Requirement: Disallowed Email Callback Returns Unauthorized
-
-The system MUST return HTTP `401 Unauthorized` when the Google OAuth callback resolves a user whose email is not allowed by configured policy.
-
-#### Scenario: Disallowed email in callback
-
-- GIVEN a valid callback request (`state` and `code`) and provider user info with a disallowed email
-- WHEN the callback handler evaluates allowlist policy
-- THEN the response status SHALL be `401`
-- AND the login session/token issuance MUST NOT proceed
-
-### Requirement: Unauthorized Payload Remains Clear and Actionable
-
-The system MUST preserve a clear, actionable response payload for disallowed-email callback responses; the payload semantics SHOULD remain unchanged except for status alignment to `401`.
-
-#### Scenario: Payload clarity for disallowed email
-
-- GIVEN a callback request that reaches the disallowed-email branch
-- WHEN the handler returns unauthorized
-- THEN the response payload MUST include the same explicit disallowed-email meaning used previously
-- AND clients SHALL be able to identify the response as an authorization failure without ambiguity
-
-### Requirement: Callback Test Suite Reflects Unauthorized Contract
-
-The callback test suite MUST assert `401` for disallowed-email outcomes and MUST continue to cover both success and error branches.
-
-#### Scenario: Test expectation updated for disallowed email
-
-- GIVEN callback tests for disallowed-email handling
-- WHEN tests execute against current callback behavior
-- THEN expected status MUST be `401`
-- AND assertions for payload clarity SHALL remain validated
-
-#### Scenario: Success flow regression guard remains intact
-
-- GIVEN callback tests for allowed-email login flow
-- WHEN tests execute after unauthorized-status alignment
-- THEN successful callback/login behavior MUST remain unchanged
-- AND success-path assertions SHALL continue to pass
+## ADDED Requirements
 
 ### Requirement: Callback Token Cookie Applies Configured SameSite Modes
 

--- a/openspec/changes/archive/2026-04-25-issue-3-cookie-samesite/tasks.md
+++ b/openspec/changes/archive/2026-04-25-issue-3-cookie-samesite/tasks.md
@@ -1,0 +1,23 @@
+# Tasks: Apply configured SameSite on Google callback token cookie
+
+## Phase 1: Foundation
+
+- [x] 1.1 Add SameSite parsing helper in `internal/infrastructure/port/in/google/routes.go` (e.g., `parseSameSite(raw string) http.SameSite`) using trimmed, case-insensitive mapping for `Strict|Lax|None`; default to zero value for empty/invalid.
+- [x] 1.2 Refactor callback cookie emission in `GoogleCallbackHandler` (`internal/infrastructure/port/in/google/routes.go`) to use `http.SetCookie` with explicit `http.Cookie` fields and parsed SameSite, preserving existing name/path/value/MaxAge/HttpOnly/Secure behavior.
+
+## Phase 2: Core implementation wiring
+
+- [x] 2.1 Ensure callback success flow still follows existing redirect/JSON behavior after cookie write changes in `internal/infrastructure/port/in/google/routes.go`.
+- [x] 2.2 Keep sign-out and non-callback cookie code paths unchanged in `internal/infrastructure/port/in/google/routes.go` (no scope creep to shared cookie abstractions).
+
+## Phase 3: Verification tests
+
+- [x] 3.1 Add table-driven subtests in `internal/infrastructure/port/in/google/routes_test.go` for callback success asserting `Set-Cookie` contains `SameSite=Strict`, `SameSite=Lax`, `SameSite=None` when config values use mixed casing.
+- [x] 3.2 Add table-driven subtests in `internal/infrastructure/port/in/google/routes_test.go` for empty and invalid `security.cookie.same-site` asserting `Set-Cookie` omits any `SameSite` attribute.
+- [x] 3.3 Add regression assertions in callback success tests for `Secure`, `HttpOnly`, and `Max-Age` to match pre-change behavior for both valid and fallback SameSite paths.
+- [x] 3.4 Re-run existing callback branch tests in `internal/infrastructure/port/in/google/routes_test.go` (invalid state, missing code, provider error, token error, email not allowed, redirect/no-redirect success) to confirm no functional regressions.
+
+## Phase 4: Final validation
+
+- [x] 4.1 Run `go test ./internal/infrastructure/port/in/google -v` and ensure all new/existing route tests pass.
+- [x] 4.2 Run `go test ./...` to verify repo-wide behavior remains stable after cookie handling change.

--- a/openspec/changes/archive/2026-04-25-issue-3-cookie-samesite/verify-report.md
+++ b/openspec/changes/archive/2026-04-25-issue-3-cookie-samesite/verify-report.md
@@ -1,0 +1,147 @@
+# Verification Report
+
+**Change**: issue-3-cookie-samesite  
+**Version**: N/A (delta spec)  
+**Mode**: Strict TDD
+
+---
+
+### Completeness
+| Metric | Value |
+|--------|-------|
+| Tasks total | 10 |
+| Tasks complete | 10 |
+| Tasks incomplete | 0 |
+
+All tasks in `openspec/changes/issue-3-cookie-samesite/tasks.md` are marked complete.
+
+---
+
+### Build & Tests Execution
+
+**Build**: ✅ Passed
+```text
+go build ./...
+(no output)
+exit code: 0
+```
+
+**Tests**: ✅ 146 passed / ❌ 0 failed / ⚠️ 0 skipped
+```text
+Primary command: go test ./... -count=1
+Package results: all passing
+
+JSON-run summary:
+run=146 pass=146 fail=0 skip=0
+```
+
+**Coverage**: 86.2% total / threshold: not configured → ➖ Informational
+
+---
+
+### TDD Compliance
+| Check | Result | Details |
+|-------|--------|---------|
+| TDD Evidence reported | ✅ | `apply-progress.md` contains a full "TDD Cycle Evidence" table |
+| All tasks have tests | ✅ | 5/5 evidence rows mapped to test files/verification commands |
+| RED confirmed (tests exist) | ✅ | 2/2 RED-required rows have existing tests in `routes_test.go` |
+| GREEN confirmed (tests pass) | ✅ | Corresponding tests pass in package + repo execution |
+| Triangulation adequate | ✅ | 2 implementation rows triangulated with 5-case tables each |
+| Safety Net for modified files | ✅ | Baseline package tests recorded before change; regression suite re-run |
+
+**TDD Compliance**: 6/6 checks passed
+
+---
+
+### Test Layer Distribution
+| Layer | Tests | Files | Tools |
+|-------|-------|-------|-------|
+| Unit | 5 (parseSameSite subtests) | 1 | `go test` |
+| Integration | 5 (callback SameSite mapping subtests) | 1 | `net/http/httptest` + Gin router |
+| E2E | 0 | 0 | not installed |
+| **Total** | **10** | **1** | |
+
+---
+
+### Changed File Coverage
+| File | Line % | Branch % | Uncovered Lines | Rating |
+|------|--------|----------|-----------------|--------|
+| `internal/infrastructure/port/in/google/routes.go` | 100% | — | — | ✅ Excellent |
+| `internal/infrastructure/port/in/google/routes_test.go` | N/A (test file) | N/A | N/A | ➖ Not instrumented |
+| `openspec/changes/issue-3-cookie-samesite/tasks.md` | N/A (non-Go) | N/A | N/A | ➖ Not instrumented |
+
+**Average changed file coverage (instrumented files)**: 100%  
+**Total uncovered lines (instrumented changed files)**: 0
+
+---
+
+### Assertion Quality
+
+**Assertion quality**: ✅ All assertions verify real behavior
+
+Audit notes:
+- No tautologies (e.g., `expect(true).toBe(true)` style equivalents)
+- No ghost-loop assertions over potentially empty runtime query sets
+- No test without production-path execution
+- No mock-heavy anti-patterns in changed tests
+
+---
+
+### Quality Metrics
+**Linter**: ➖ Not available in cached capabilities  
+**Type Checker**: ✅ `go vet ./...` passed (no diagnostics)
+
+---
+
+### Spec Compliance Matrix
+
+| Requirement | Scenario | Test | Result |
+|-------------|----------|------|--------|
+| Callback Token Cookie Applies Configured SameSite Modes | SameSite Strict is applied | `internal/infrastructure/port/in/google/routes_test.go > TestGoogleCallbackHandler_Success_SameSiteMapping/strict_mixed_case` | ✅ COMPLIANT |
+| Callback Token Cookie Applies Configured SameSite Modes | SameSite Lax is applied | `internal/infrastructure/port/in/google/routes_test.go > TestGoogleCallbackHandler_Success_SameSiteMapping/lax_mixed_case` | ✅ COMPLIANT |
+| Callback Token Cookie Applies Configured SameSite Modes | SameSite None is applied | `internal/infrastructure/port/in/google/routes_test.go > TestGoogleCallbackHandler_Success_SameSiteMapping/none_mixed_case` | ✅ COMPLIANT |
+| Callback Token Cookie Has Deterministic SameSite Fallback | Empty SameSite config omits attribute | `internal/infrastructure/port/in/google/routes_test.go > TestGoogleCallbackHandler_Success_SameSiteMapping/empty_fallback_omits_samesite` | ✅ COMPLIANT |
+| Callback Token Cookie Has Deterministic SameSite Fallback | Invalid SameSite config omits attribute | `internal/infrastructure/port/in/google/routes_test.go > TestGoogleCallbackHandler_Success_SameSiteMapping/invalid_fallback_omits_samesite` | ✅ COMPLIANT |
+| Existing Callback Cookie Security Attributes Are Preserved | Security attributes remain unchanged for valid SameSite | `internal/infrastructure/port/in/google/routes_test.go > TestGoogleCallbackHandler_Success_SameSiteMapping/*(valid)` (asserts `Max-Age=3600`, `HttpOnly`, `Secure`) | ✅ COMPLIANT |
+| Existing Callback Cookie Security Attributes Are Preserved | Security attributes remain unchanged for fallback path | `internal/infrastructure/port/in/google/routes_test.go > TestGoogleCallbackHandler_Success_SameSiteMapping/*(fallback)` (asserts `Max-Age=3600`, `HttpOnly`, `Secure`) | ✅ COMPLIANT |
+
+**Compliance summary**: 7/7 scenarios compliant
+
+---
+
+### Correctness (Static — Structural Evidence)
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| Callback Token Cookie Applies Configured SameSite Modes | ✅ Implemented | `parseSameSite` maps trimmed, case-insensitive `Strict/Lax/None`; callback writes `SameSite` via `http.SetCookie`. |
+| Callback Token Cookie Has Deterministic SameSite Fallback | ✅ Implemented | Invalid/empty values map to `http.SameSite(0)`, resulting in omitted SameSite attribute in header assertions. |
+| Existing Callback Cookie Security Attributes Are Preserved | ✅ Implemented | Callback cookie still sets same `Path`, `MaxAge`, `HttpOnly`, and `Secure` semantics; tests assert these for valid + fallback paths. |
+
+---
+
+### Coherence (Design)
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| Handler-local SameSite mapping + explicit `http.SetCookie` in callback | ✅ Yes | Implemented in `internal/infrastructure/port/in/google/routes.go`. |
+| Avoid shared cookie abstraction/scope creep | ✅ Yes | No shared utility introduced; signout/non-callback paths untouched in this change. |
+| Invalid/empty -> zero-value SameSite (omit attribute) | ✅ Yes | `parseSameSite` default returns `http.SameSite(0)` and tests verify attribute omission. |
+| File changes match design table | ✅ Yes | Only `routes.go` and `routes_test.go` changed in code; tasks artifact updated as expected. |
+
+---
+
+### Issues Found
+
+**CRITICAL** (must fix before archive):
+None
+
+**WARNING** (should fix):
+None
+
+**SUGGESTION** (nice to have):
+- Consider adding a focused integration test in a higher-level route wiring package to validate SameSite behavior through full server route registration, not only handler-local tests.
+
+---
+
+### Verdict
+PASS
+
+All spec scenarios are behaviorally validated by passing tests, design coherence is maintained, and Strict TDD verification checks are satisfied.


### PR DESCRIPTION
Closes #3

## Summary
- Applies `security.cookie.same-site` to the Google callback `token` cookie using explicit SameSite parsing (`Strict`, `Lax`, `None`, case-insensitive).
- Adds table-driven tests for SameSite mapping and invalid/empty fallback behavior while preserving `Secure`, `HttpOnly`, and `Max-Age` assertions.
- Archives SDD hybrid artifacts for this change and adds `test-results.json` to `.gitignore` to keep generated test output out of commits.

## Changes
| File | Change |
|------|--------|
| `.gitignore` | Ignore `test-results.json` generated by test runs |
| `internal/infrastructure/port/in/google/routes.go` | Parse SameSite config and emit callback cookie with explicit `http.SetCookie` |
| `internal/infrastructure/port/in/google/routes_test.go` | Add parser tests and callback Set-Cookie SameSite mapping/fallback tests |
| `openspec/specs/google-oauth-callback/spec.md` | Sync final SameSite requirements into source-of-truth spec |
| `openspec/changes/archive/2026-04-25-issue-3-cookie-samesite/*` | Archive proposal/spec/design/tasks/apply/verify/archive artifacts |

## Test Plan
- [x] `go test ./internal/infrastructure/port/in/google -v -count=1`
- [x] `go test ./... -count=1`
- [x] No shell scripts changed (`shellcheck` not applicable)

## Checklist
- [x] Linked approved issue (`Closes #3`)
- [x] Added exactly one `type:*` label to PR
- [x] Conventional commits used
- [x] Docs/specs updated for behavior change
- [x] No `Co-Authored-By` trailers