### PR TITLE
refactor: standardize auth error payloads to align with Java contract

### DIFF
--- a/internal/infrastructure/port/in/google/routes.go
+++ b/internal/infrastructure/port/in/google/routes.go
@@ -52,40 +52,30 @@ func (h *googleOAuth2HandlerImpl) GoogleCallbackHandler(ctx *gin.Context) {
 	securityConfig := pkg.App.Config.GetSecurityConfig().GetOAuth2Config().GetGoogleConfig()
 	state := ctx.Query("state")
 	if state != securityConfig.GetState() {
-		ctx.JSON(http.StatusBadRequest, gin.H{
-			"error": "invalid state parameter",
-		})
+		pkg.WriteAuthError(ctx, http.StatusBadRequest, pkg.AuthCodeCallbackStateInvalid, "invalid state parameter")
 		return
 	}
 
 	code := ctx.Query("code")
 	if code == "" {
-		ctx.JSON(http.StatusBadRequest, gin.H{
-			"error": "code parameter is missing",
-		})
+		pkg.WriteAuthError(ctx, http.StatusBadRequest, pkg.AuthCodeCallbackCodeMissing, "code parameter is missing")
 		return
 	}
 
 	userInfo, err := h.providerRepository.GetUserInfo(ctx, code)
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, gin.H{
-			"error": "failed to get user info",
-		})
+		pkg.WriteAuthError(ctx, http.StatusInternalServerError, pkg.AuthCodeProviderFailure, "authentication provider unavailable")
 		return
 	}
 
 	if !userInfo.IsEmailAllowed() {
-		ctx.JSON(http.StatusUnauthorized, gin.H{
-			"error": "email is not allowed",
-		})
+		pkg.WriteAuthError(ctx, http.StatusUnauthorized, pkg.AuthCodeEmailNotAllowed, "email is not allowed")
 		return
 	}
 
 	token, err := h.tokenGenerator.GenerateToken(userInfo)
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, gin.H{
-			"error": "failed to generate token",
-		})
+		pkg.WriteAuthError(ctx, http.StatusInternalServerError, pkg.AuthCodeTokenGenerationFailed, "failed to generate authentication token")
 		return
 	}
 

--- a/internal/infrastructure/port/in/google/routes_test.go
+++ b/internal/infrastructure/port/in/google/routes_test.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -12,11 +13,22 @@ import (
 	"github.com/matiasmartin-labs/auth-provider-ms/internal/domain/model"
 	"github.com/matiasmartin-labs/auth-provider-ms/pkg"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 )
 
 func init() {
 	gin.SetMode(gin.TestMode)
+}
+
+func decodeAuthErrorPayload(t *testing.T, body []byte) map[string]string {
+	t.Helper()
+
+	var payload map[string]string
+	err := json.Unmarshal(body, &payload)
+	require.NoError(t, err)
+
+	return payload
 }
 
 type mockProviderRepository struct {
@@ -202,7 +214,12 @@ func TestGoogleCallbackHandler_InvalidState(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "invalid state parameter")
+	payload := decodeAuthErrorPayload(t, w.Body.Bytes())
+	assert.Equal(t, pkg.AuthCodeCallbackStateInvalid, payload["code"])
+	assert.Equal(t, "invalid state parameter", payload["message"])
+	assert.Len(t, payload, 2)
+	_, hasLegacyError := payload["error"]
+	assert.False(t, hasLegacyError)
 }
 
 func TestGoogleCallbackHandler_MissingCode(t *testing.T) {
@@ -219,7 +236,12 @@ func TestGoogleCallbackHandler_MissingCode(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "code parameter is missing")
+	payload := decodeAuthErrorPayload(t, w.Body.Bytes())
+	assert.Equal(t, pkg.AuthCodeCallbackCodeMissing, payload["code"])
+	assert.Equal(t, "code parameter is missing", payload["message"])
+	assert.Len(t, payload, 2)
+	_, hasLegacyError := payload["error"]
+	assert.False(t, hasLegacyError)
 }
 
 func TestGoogleCallbackHandler_ProviderError(t *testing.T) {
@@ -240,7 +262,12 @@ func TestGoogleCallbackHandler_ProviderError(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
-	assert.Contains(t, w.Body.String(), "failed to get user info")
+	payload := decodeAuthErrorPayload(t, w.Body.Bytes())
+	assert.Equal(t, pkg.AuthCodeProviderFailure, payload["code"])
+	assert.Equal(t, "authentication provider unavailable", payload["message"])
+	assert.Len(t, payload, 2)
+	_, hasLegacyError := payload["error"]
+	assert.False(t, hasLegacyError)
 }
 
 func TestGoogleCallbackHandler_EmailNotAllowed(t *testing.T) {
@@ -248,16 +275,22 @@ func TestGoogleCallbackHandler_EmailNotAllowed(t *testing.T) {
 		name            string
 		redirectEnabled bool
 		redirectURL     string
+		expectedCode    string
+		expectedMessage string
 	}{
 		{
 			name:            "without redirect",
 			redirectEnabled: false,
 			redirectURL:     "",
+			expectedCode:    pkg.AuthCodeEmailNotAllowed,
+			expectedMessage: "email is not allowed",
 		},
 		{
 			name:            "with redirect configured",
 			redirectEnabled: true,
 			redirectURL:     "http://localhost:3000/dashboard",
+			expectedCode:    pkg.AuthCodeEmailNotAllowed,
+			expectedMessage: "email is not allowed",
 		},
 	}
 
@@ -284,7 +317,12 @@ func TestGoogleCallbackHandler_EmailNotAllowed(t *testing.T) {
 			router.ServeHTTP(w, req)
 
 			assert.Equal(t, http.StatusUnauthorized, w.Code)
-			assert.Contains(t, w.Body.String(), "email is not allowed")
+			payload := decodeAuthErrorPayload(t, w.Body.Bytes())
+			assert.Equal(t, tc.expectedCode, payload["code"])
+			assert.Equal(t, tc.expectedMessage, payload["message"])
+			assert.Len(t, payload, 2)
+			_, hasLegacyError := payload["error"]
+			assert.False(t, hasLegacyError)
 			assert.Empty(t, w.Result().Cookies())
 			assert.Empty(t, w.Header().Get("Location"))
 		})
@@ -317,7 +355,12 @@ func TestGoogleCallbackHandler_TokenGenerationError(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
-	assert.Contains(t, w.Body.String(), "failed to generate token")
+	payload := decodeAuthErrorPayload(t, w.Body.Bytes())
+	assert.Equal(t, pkg.AuthCodeTokenGenerationFailed, payload["code"])
+	assert.Equal(t, "failed to generate authentication token", payload["message"])
+	assert.Len(t, payload, 2)
+	_, hasLegacyError := payload["error"]
+	assert.False(t, hasLegacyError)
 }
 
 func TestGoogleCallbackHandler_Success_NoRedirect(t *testing.T) {

--- a/internal/infrastructure/port/in/me/routes.go
+++ b/internal/infrastructure/port/in/me/routes.go
@@ -16,17 +16,13 @@ type MeResponse struct {
 func MeHandler(ctx *gin.Context) {
 	claimsValue, exists := ctx.Get("claims")
 	if !exists {
-		ctx.JSON(http.StatusUnauthorized, gin.H{
-			"error": "no authentication claims found",
-		})
+		pkg.WriteAuthError(ctx, http.StatusUnauthorized, pkg.AuthCodeClaimsMissing, "no authentication claims found")
 		return
 	}
 
 	claims, ok := claimsValue.(*pkg.Claims)
 	if !ok {
-		ctx.JSON(http.StatusInternalServerError, gin.H{
-			"error": "invalid claims format",
-		})
+		pkg.WriteAuthError(ctx, http.StatusInternalServerError, pkg.AuthCodeClaimsInvalid, "invalid authentication claims")
 		return
 	}
 

--- a/internal/infrastructure/port/in/me/routes_test.go
+++ b/internal/infrastructure/port/in/me/routes_test.go
@@ -59,7 +59,16 @@ func TestMeHandler_NoClaims(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
-	assert.Contains(t, w.Body.String(), "no authentication claims found")
+
+	var payload map[string]string
+	err := json.Unmarshal(w.Body.Bytes(), &payload)
+	require.NoError(t, err)
+
+	assert.Equal(t, pkg.AuthCodeClaimsMissing, payload["code"])
+	assert.Equal(t, "no authentication claims found", payload["message"])
+	assert.Len(t, payload, 2)
+	_, hasLegacyError := payload["error"]
+	assert.False(t, hasLegacyError)
 }
 
 func TestMeHandler_InvalidClaimsFormat(t *testing.T) {
@@ -75,7 +84,16 @@ func TestMeHandler_InvalidClaimsFormat(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
-	assert.Contains(t, w.Body.String(), "invalid claims format")
+
+	var payload map[string]string
+	err := json.Unmarshal(w.Body.Bytes(), &payload)
+	require.NoError(t, err)
+
+	assert.Equal(t, pkg.AuthCodeClaimsInvalid, payload["code"])
+	assert.Equal(t, "invalid authentication claims", payload["message"])
+	assert.Len(t, payload, 2)
+	_, hasLegacyError := payload["error"]
+	assert.False(t, hasLegacyError)
 }
 
 func TestMeHandler_EmptyFields(t *testing.T) {

--- a/openspec/changes/archive/2026-04-25-issue-4-standardize-auth-error-payloads/archive-report.md
+++ b/openspec/changes/archive/2026-04-25-issue-4-standardize-auth-error-payloads/archive-report.md
@@ -1,0 +1,39 @@
+# Archive Report: issue-4-standardize-auth-error-payloads
+
+## Summary
+
+Archived `issue-4-standardize-auth-error-payloads` after verification verdict **PASS WITH WARNINGS** with **no critical issues**. Delta specs were merged into source-of-truth specs before moving the change folder into archive.
+
+## Traceability (Engram Observation IDs)
+
+- explore: `sdd/issue-4-standardize-auth-error-payloads/explore` → **#149**
+- proposal: `sdd/issue-4-standardize-auth-error-payloads/proposal` → **#150**
+- spec: `sdd/issue-4-standardize-auth-error-payloads/spec` → **#151**
+- design: `sdd/issue-4-standardize-auth-error-payloads/design` → **#152**
+- tasks: `sdd/issue-4-standardize-auth-error-payloads/tasks` → **#155**
+- apply-progress: `sdd/issue-4-standardize-auth-error-payloads/apply-progress` → **#159**
+- verify-report: `sdd/issue-4-standardize-auth-error-payloads/verify-report` → **#161**
+
+## Spec Sync Actions
+
+| Domain | Action | Details |
+|---|---|---|
+| `auth-error-payloads` | Created | New main spec created at `openspec/specs/auth-error-payloads/spec.md` from delta full spec. |
+| `google-oauth-callback` | Updated | Merged MODIFIED requirements: `Unauthorized Payload Remains Clear and Actionable` and `Callback Test Suite Reflects Unauthorized Contract` with standardized `code`/`message` envelope scenarios. |
+
+## Archive Move
+
+- From: `openspec/changes/issue-4-standardize-auth-error-payloads/`
+- To: `openspec/changes/archive/2026-04-25-issue-4-standardize-auth-error-payloads/`
+
+## Verification Checks
+
+- [x] Main specs updated correctly
+- [x] Change folder moved to archive
+- [x] Archive contains proposal/specs/design/tasks/verify artifacts
+- [x] Active changes directory no longer contains this change
+
+## Notes
+
+- `openspec/config.yaml` is not present in this repository, so no project-specific `rules.archive` overrides were applied.
+- Verify report warnings were non-blocking (documentation/process drift), so archive proceeded per skill rule (no CRITICAL issues).

--- a/openspec/changes/archive/2026-04-25-issue-4-standardize-auth-error-payloads/design.md
+++ b/openspec/changes/archive/2026-04-25-issue-4-standardize-auth-error-payloads/design.md
@@ -1,0 +1,103 @@
+# Design: Standardize Auth Error Payloads
+
+## Technical Approach
+
+Introduce a small shared auth-error contract in `pkg` and route all in-scope auth failure branches through that contract. The implementation maps each known auth failure condition to a stable `code` and client-facing `message`, then emits JSON via a helper so middleware and handlers stay thin. This follows the proposal scope: `AuthMiddleware` unauthorized responses plus Google callback auth-related error branches, with optional `me` alignment only for auth-scoped failures.
+
+## Architecture Decisions
+
+### Decision: Centralize auth error envelope
+
+| Option | Tradeoff | Decision |
+|---|---|---|
+| Inline `gin.H{"code","message"}` at each call site | Fast, but duplicates constants and risks drift | ❌ |
+| Shared contract type + helper in `pkg` | Small refactor, but single source of truth and reusable tests | ✅ |
+| Global error middleware for all routes | Strong consistency, but out of scope and high regression risk | ❌ |
+
+**Choice**: Shared contract helper in `pkg`.
+**Rationale**: Matches current architecture (handlers call package-level helpers), minimizes scope, and reduces future divergence.
+
+### Decision: Stabilize auth codes with scoped taxonomy
+
+| Option | Tradeoff | Decision |
+|---|---|---|
+| Keep free-form messages only | Human-readable, but not machine-actionable | ❌ |
+| Add stable auth `code` + user-safe `message` | Requires taxonomy governance, but enables deterministic clients/tests | ✅ |
+
+**Choice**: Emit `code` and `message` for in-scope auth failures.
+**Rationale**: Satisfies proposal/spec intent for predictable client behavior without changing success payloads.
+
+## Data Flow
+
+Auth failures converge to one response path:
+
+    Request → Middleware/Handler branch check
+                     │
+                     ├─ missing/invalid token (middleware)
+                     ├─ invalid callback params
+                     ├─ disallowed email
+                     └─ provider/token auth failure
+                             │
+                             v
+                 pkg.WriteAuthError(ctx, status, code, message)
+                             │
+                             v
+                 HTTP JSON {"code": "...", "message": "..."}
+
+Success branches (token set, redirect/200) remain unchanged.
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `pkg/auth_error.go` | Create | Defines shared auth error payload type, constants, and writer helper used by middleware/handlers. |
+| `pkg/security-middleware.go` | Modify | Replace `{"error": ...}` unauthorized payloads with shared helper and stable codes for missing/invalid token. |
+| `internal/infrastructure/port/in/google/routes.go` | Modify | Map callback auth-related branches to shared helper (`400/401/500` with stable auth codes/messages). |
+| `internal/infrastructure/port/in/me/routes.go` | Modify (conditional) | Align auth-related `claims` missing/invalid branches to shared contract if confirmed in scope. |
+| `pkg/security-middleware_test.go` | Modify | Assert status and exact `code`/`message` contract instead of message-only substring checks. |
+| `internal/infrastructure/port/in/google/routes_test.go` | Modify | Assert standardized error envelope for invalid state/code, disallowed email, and provider/token failures. |
+| `internal/infrastructure/port/in/me/routes_test.go` | Modify (conditional) | Assert standardized envelope for auth-scoped failure branches if `me` remains in scope. |
+
+## Interfaces / Contracts
+
+```go
+// pkg/auth_error.go
+type AuthErrorResponse struct {
+    Code    string `json:"code"`
+    Message string `json:"message"`
+}
+
+func WriteAuthError(ctx *gin.Context, status int, code, message string)
+
+const (
+    AuthCodeTokenMissing   = "AUTH_TOKEN_MISSING"
+    AuthCodeTokenInvalid   = "AUTH_TOKEN_INVALID"
+    AuthCodeCallbackState  = "AUTH_CALLBACK_STATE_INVALID"
+    AuthCodeCallbackCode   = "AUTH_CALLBACK_CODE_MISSING"
+    AuthCodeEmailDenied    = "AUTH_EMAIL_NOT_ALLOWED"
+    AuthCodeProviderFailed = "AUTH_PROVIDER_FAILURE"
+    AuthCodeTokenIssue     = "AUTH_TOKEN_GENERATION_FAILED"
+)
+```
+
+Contract constraints:
+- Envelope fields for in-scope auth failures are `code` and `message`.
+- `message` stays safe/actionable (no internals); internal errors are not leaked.
+- Codes are stable identifiers for clients and tests.
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Unit | Helper emits exact JSON shape and status | Table-driven tests for `WriteAuthError` (status, code, message keys only). |
+| Integration | Middleware + callback branches return mapped codes | Existing Gin route tests updated to decode JSON and assert exact contract per branch. |
+| E2E | Auth login/callback happy path unchanged | Run existing callback success tests (redirect/no redirect, cookie behavior) as regression guard. |
+
+## Migration / Rollout
+
+No migration required. Rollout is code-only and backward-compatible for successful responses; only in-scope auth error payloads change shape.
+
+## Open Questions
+
+- [ ] Confirm final code taxonomy in spec delta (exact enum set and naming).
+- [ ] Confirm whether `internal/infrastructure/port/in/me/routes.go` fallback errors are explicitly in-scope for this issue.

--- a/openspec/changes/archive/2026-04-25-issue-4-standardize-auth-error-payloads/exploration.md
+++ b/openspec/changes/archive/2026-04-25-issue-4-standardize-auth-error-payloads/exploration.md
@@ -1,0 +1,41 @@
+## Exploration: issue-4-standardize-auth-error-payloads
+
+### Current State
+Auth-related responses currently return mixed JSON error payloads that all use a single `error` string field, but with no shared contract type or stable machine-readable code. The two main paths in scope are: (1) `AuthMiddleware` in `pkg/security-middleware.go` (missing/invalid token → `401`), and (2) Google OAuth callback in `internal/infrastructure/port/in/google/routes.go` (invalid state/code `400`, disallowed email `401`, provider/token failures `500`). Tests mostly assert status and substring message, not a shared structured contract.
+
+### Affected Areas
+- `pkg/security-middleware.go` — currently emits `{"error": "..."}` for unauthorized responses; must adopt standardized auth error schema.
+- `pkg/security-middleware_test.go` — assertions currently check raw message substrings; should assert schema keys and stable code/message semantics.
+- `internal/infrastructure/port/in/google/routes.go` — callback error branches currently emit `{"error": "..."}` for bad request/unauthorized/internal errors.
+- `internal/infrastructure/port/in/google/routes_test.go` — callback tests must assert the same schema on unauthorized/error branches.
+- `internal/infrastructure/port/in/me/routes.go` — contains fallback unauthorized/internal errors and may need alignment to avoid contract drift on auth endpoint behavior.
+- `internal/infrastructure/port/in/me/routes_test.go` — if `me` fallback responses are included in scope, tests need schema assertions.
+- `openspec/specs/google-oauth-callback/spec.md` — currently specifies payload clarity but not a concrete schema; follow-up spec delta should codify canonical fields.
+
+### Approaches
+1. **Inline replacement per handler/middleware** — Replace every `gin.H{"error": ...}` in scoped files with `gin.H{"code": ..., "message": ...}` directly.
+   - Pros: Fastest path, low implementation overhead, minimal file churn.
+   - Cons: Duplicates mapping logic and string constants; higher risk of future drift and inconsistent codes.
+   - Effort: Low.
+
+2. **Shared auth error contract helper (recommended)** — Introduce a small shared helper/type for auth error responses (e.g., `code` + `message`) and use it from middleware + callback branches.
+   - Pros: Enforces one schema at compile-time usage points, improves consistency, cleaner tests, easier future expansion.
+   - Cons: Slight upfront refactor and naming decisions; requires careful scope control to avoid broad API refactor.
+   - Effort: Medium.
+
+3. **Global error middleware normalization** — Centralize all error responses via Gin middleware and map auth failures into unified envelope.
+   - Pros: Strong long-term consistency across all endpoints.
+   - Cons: Over-scoped for this issue; requires broader handler error propagation changes and larger regression surface.
+   - Effort: High.
+
+### Recommendation
+Use **Approach 2 (Shared auth error contract helper)** with strict scope to issue #4: middleware + OAuth2 callback unauthorized/error branches (and optionally `me` fallback if considered in-scope during proposal/spec clarification). This best balances contract consistency (Java-aligned `code` + `message`) with low regression risk, while avoiding a larger global error architecture change.
+
+### Risks
+- **Contract ambiguity risk**: Issue notes “for example, code + message” but not exact enum values; codes must be agreed (e.g., `AUTH_TOKEN_MISSING`, `AUTH_TOKEN_INVALID`, `AUTH_EMAIL_NOT_ALLOWED`, etc.) before implementation.
+- **Scope creep risk**: Expanding to all endpoint errors (e.g., JWKS/non-auth) may delay delivery; keep scope explicit to auth-related branches.
+- **Test brittleness risk**: Existing tests rely on substring matching; converting to strict JSON structure assertions may require broader updates than expected.
+- **OpenSpec context gap**: `openspec/config.yaml` is currently absent, so phase-specific local OpenSpec rules cannot be validated from repo config.
+
+### Ready for Proposal
+Yes — enough code and test context exists to draft proposal/spec/tasks for a focused refactor that introduces one auth error schema and applies it consistently to middleware and OAuth2 callback error paths.

--- a/openspec/changes/archive/2026-04-25-issue-4-standardize-auth-error-payloads/proposal.md
+++ b/openspec/changes/archive/2026-04-25-issue-4-standardize-auth-error-payloads/proposal.md
@@ -1,0 +1,61 @@
+# Proposal: Standardize Auth Error Payloads
+
+## Intent
+
+Auth endpoints currently return inconsistent `{"error":"..."}` payloads with no machine-readable contract. This change standardizes auth failures to a shared JSON shape (`code`, `message`) so clients can handle errors predictably across middleware and OAuth callback paths.
+
+## Scope
+
+### In Scope
+- Define one shared auth error response contract and helper for HTTP handlers/middleware.
+- Apply the contract to `AuthMiddleware` unauthorized branches (missing/invalid token).
+- Apply the contract to Google OAuth callback auth-related error branches (invalid request, disallowed email, provider/token failures) and align tests to assert schema + stable codes.
+
+### Out of Scope
+- Global non-auth error normalization for all routes.
+- Changes to success payloads, cookie/session behavior, or OAuth happy path semantics.
+
+## Capabilities
+
+### New Capabilities
+- `auth-error-payloads`: Defines canonical auth error envelope fields (`code`, `message`), code stability expectations, and response behavior for middleware/me-auth failures.
+
+### Modified Capabilities
+- `google-oauth-callback`: Tightens callback error payload contract to use standardized auth error envelope for relevant error branches.
+
+## Approach
+
+Implement a small shared auth error helper/type (recommended from exploration) and reuse it in scoped handlers. Keep handlers thin: map branch condition → stable auth code/message → status. Update tests to validate status plus response keys/values, avoiding fragile substring-only checks.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `pkg/security-middleware.go` | Modified | Replace ad-hoc unauthorized payloads with shared auth error envelope |
+| `pkg/security-middleware_test.go` | Modified | Assert `code`/`message` contract |
+| `internal/infrastructure/port/in/google/routes.go` | Modified | Use shared auth error envelope in callback error branches |
+| `internal/infrastructure/port/in/google/routes_test.go` | Modified | Assert standardized callback error payloads |
+| `internal/infrastructure/port/in/me/routes.go` | Modified | Align auth-related fallback errors to shared envelope (if branch is in auth scope) |
+| `openspec/changes/issue-4-standardize-auth-error-payloads/specs/*` | New | Delta specs for new/modified capabilities |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Auth code taxonomy ambiguity | Med | Freeze code set in spec phase before implementation |
+| Scope creep into all API errors | Med | Restrict to auth-related branches only |
+| Test churn from stricter assertions | Med | Use table-driven assertions for stable schema contract |
+
+## Rollback Plan
+
+Revert helper usage in scoped files to prior payload shape and restore prior tests in the same commit window; no schema/data migration is required.
+
+## Dependencies
+
+- Exploration artifact: `sdd/issue-4-standardize-auth-error-payloads/explore` and `openspec/changes/issue-4-standardize-auth-error-payloads/exploration.md`.
+
+## Success Criteria
+
+- [ ] Scoped auth error responses return JSON with `code` and `message` only (or documented envelope fields).
+- [ ] Middleware + OAuth callback tests assert standardized payload contract and pass.
+- [ ] Spec deltas clearly define code/message semantics for affected capabilities.

--- a/openspec/changes/archive/2026-04-25-issue-4-standardize-auth-error-payloads/specs/auth-error-payloads/spec.md
+++ b/openspec/changes/archive/2026-04-25-issue-4-standardize-auth-error-payloads/specs/auth-error-payloads/spec.md
@@ -1,0 +1,47 @@
+# Auth Error Payloads Specification
+
+## Purpose
+
+Define a canonical auth error payload contract so auth failures are machine-readable and consistent across middleware and auth-scoped endpoints.
+
+## Requirements
+
+### Requirement: Canonical Auth Error Envelope
+
+The system MUST return auth failures as a JSON object containing exactly `code` and `message` fields.
+
+#### Scenario: Middleware auth failure uses canonical envelope
+
+- GIVEN an auth request evaluated by middleware
+- WHEN the request is rejected for authentication reasons
+- THEN the response body MUST include `code` and `message`
+- AND the response body MUST NOT include legacy `error` as the contract field
+
+### Requirement: Auth Error Codes Are Stable and Branch-Specific
+
+The system SHALL use stable, branch-specific auth error codes so clients can reliably branch on failure type across releases.
+
+#### Scenario: Missing token maps to stable code
+
+- GIVEN a protected route request with no token
+- WHEN middleware rejects the request
+- THEN status MUST be `401`
+- AND `code` SHALL be `auth_token_missing`
+
+#### Scenario: Invalid token maps to stable code
+
+- GIVEN a protected route request with an invalid token
+- WHEN middleware rejects the request
+- THEN status MUST be `401`
+- AND `code` SHALL be `auth_token_invalid`
+
+### Requirement: Messages Are Client-Safe and Actionable
+
+The system MUST provide a client-safe `message` suitable for user/client handling and MUST NOT expose internal stack or provider internals in auth error responses.
+
+#### Scenario: Message omits internal details
+
+- GIVEN an auth-scoped endpoint returns an auth failure
+- WHEN the response is serialized
+- THEN `message` MUST describe the failure class in user-safe terms
+- AND `message` MUST NOT include internal stack traces, secrets, or provider internals

--- a/openspec/changes/archive/2026-04-25-issue-4-standardize-auth-error-payloads/specs/google-oauth-callback/spec.md
+++ b/openspec/changes/archive/2026-04-25-issue-4-standardize-auth-error-payloads/specs/google-oauth-callback/spec.md
@@ -1,0 +1,41 @@
+# Delta for Google OAuth Callback
+
+## MODIFIED Requirements
+
+### Requirement: Unauthorized Payload Remains Clear and Actionable
+
+The system MUST return the standardized auth error envelope for auth-related callback failures, with clear and actionable client-safe semantics.
+(Previously: Payload meaning stayed implicit and tied to legacy error-string semantics.)
+
+#### Scenario: Disallowed email returns canonical auth envelope
+
+- GIVEN a callback request that reaches the disallowed-email branch
+- WHEN the handler returns unauthorized
+- THEN the response status SHALL be `401`
+- AND the payload MUST include `code=auth_email_not_allowed` and a client-safe `message`
+
+#### Scenario: Callback auth failure payload remains unambiguous
+
+- GIVEN a callback request that reaches an auth-related failure branch
+- WHEN the handler returns an auth failure response
+- THEN the payload MUST use `code` and `message` fields
+- AND clients SHALL identify authorization failure type from `code` without parsing free text
+
+### Requirement: Callback Test Suite Reflects Unauthorized Contract
+
+The callback test suite MUST assert standardized auth error envelope behavior for auth-related callback failures while continuing to cover success and error branches.
+(Previously: Tests asserted unauthorized status and payload clarity, but not stable envelope fields/codes.)
+
+#### Scenario: Tests assert standardized callback auth error contract
+
+- GIVEN callback tests for disallowed-email and other auth-related failure handling
+- WHEN tests execute against current callback behavior
+- THEN expected payload assertions MUST include `code` and `message`
+- AND expected status/code pairs SHALL be validated for each covered branch
+
+#### Scenario: Success flow regression guard remains intact
+
+- GIVEN callback tests for allowed-email login flow
+- WHEN tests execute after auth error payload standardization
+- THEN successful callback/login behavior MUST remain unchanged
+- AND success-path assertions SHALL continue to pass

--- a/openspec/changes/archive/2026-04-25-issue-4-standardize-auth-error-payloads/tasks.md
+++ b/openspec/changes/archive/2026-04-25-issue-4-standardize-auth-error-payloads/tasks.md
@@ -1,0 +1,31 @@
+# Tasks: Standardize Auth Error Payloads
+
+## Phase 1: Contract Foundation
+
+- [x] 1.1 Create `pkg/auth_error.go` with `AuthErrorResponse` and `WriteAuthError(ctx, status, code, message)` that always serializes `code` and `message` only.
+- [x] 1.2 Define and export stable auth code constants in `pkg/auth_error.go` using spec-aligned snake_case values (`auth_token_missing`, `auth_token_invalid`, callback/auth branch codes).
+- [x] 1.3 Add `pkg/auth_error_test.go` table-driven tests validating status, exact JSON keys (`code`,`message`), and absence of legacy `error` field.
+
+## Phase 2: Middleware and Me Endpoint Alignment
+
+- [x] 2.1 Refactor `pkg/security-middleware.go` unauthorized branches (missing token, invalid/expired token) to call `WriteAuthError` with stable codes and client-safe messages.
+- [x] 2.2 Update `pkg/security-middleware_test.go` to decode JSON and assert exact status/code/message contract for rejected auth requests.
+- [x] 2.3 Confirm `internal/infrastructure/port/in/me/routes.go` scope from issue/design open question; if in scope, replace auth-related failure payloads with shared auth envelope and stable codes.
+- [x] 2.4 If 2.3 is in scope, update `internal/infrastructure/port/in/me/routes_test.go` with contract assertions for claims-missing/invalid branches.
+
+## Phase 3: Google Callback Standardization
+
+- [x] 3.1 Refactor `internal/infrastructure/port/in/google/routes.go` invalid callback input branches (state mismatch, missing code) to emit standardized auth envelope via helper.
+- [x] 3.2 Refactor callback auth failure branches in `internal/infrastructure/port/in/google/routes.go` (disallowed email, provider failure, token generation failure) to mapped stable codes and client-safe messages.
+- [x] 3.3 Preserve success behavior in `internal/infrastructure/port/in/google/routes.go` (cookie set, redirect/no-redirect, token success payload) unchanged.
+
+## Phase 4: Integration Verification
+
+- [x] 4.1 Update `internal/infrastructure/port/in/google/routes_test.go` using named table-driven subtests to assert status + exact `code`/`message` across auth failure branches.
+- [x] 4.2 Add/adjust assertions in middleware and callback tests that legacy `error` contract field is not returned for standardized auth failures.
+- [x] 4.3 Run targeted regression tests: `go test ./pkg ./internal/infrastructure/port/in/google ./internal/infrastructure/port/in/me` and fix any contract mismatches.
+
+## Phase 5: Final Consistency Pass
+
+- [x] 5.1 Review all in-scope auth failure responses to ensure internal/provider details are not leaked in `message` values.
+- [x] 5.2 Confirm implementation matches spec scenarios in `openspec/changes/issue-4-standardize-auth-error-payloads/specs/**` before handing off to `sdd-apply`.

--- a/openspec/changes/archive/2026-04-25-issue-4-standardize-auth-error-payloads/verify-report.md
+++ b/openspec/changes/archive/2026-04-25-issue-4-standardize-auth-error-payloads/verify-report.md
@@ -1,0 +1,141 @@
+## Verification Report
+
+**Change**: issue-4-standardize-auth-error-payloads
+**Version**: N/A
+**Mode**: Strict TDD
+
+---
+
+### Completeness
+| Metric | Value |
+|--------|-------|
+| Tasks total | 15 |
+| Tasks complete | 15 |
+| Tasks incomplete | 0 |
+
+All tasks in `openspec/changes/issue-4-standardize-auth-error-payloads/tasks.md` are marked complete.
+
+---
+
+### Build & Tests Execution
+
+**Build / Type Check**: ✅ Passed (`go vet ./...`)
+```text
+(no output)
+```
+
+**Tests**: ✅ Passed
+- Full suite: `go test ./...` ✅ (exit code 0)
+- Targeted changed areas: `go test -count=1 ./pkg ./internal/infrastructure/port/in/google ./internal/infrastructure/port/in/me` ✅
+- Changed test files executed with JSON evidence and no failures:
+  - `pkg/auth_error_test.go`
+  - `pkg/security-middleware_test.go`
+  - `internal/infrastructure/port/in/google/routes_test.go`
+  - `internal/infrastructure/port/in/me/routes_test.go`
+
+**Coverage**: 86.4% total (`go test -count=1 -coverprofile=coverage.out ./... && go tool cover -func=coverage.out`) → ✅ Informational (no threshold configured)
+
+---
+
+### TDD Compliance
+| Check | Result | Details |
+|-------|--------|---------|
+| TDD Evidence reported | ✅ | `apply-progress` artifact (`sdd/issue-4-standardize-auth-error-payloads/apply-progress`) contains TDD Cycle Evidence table |
+| All tasks have tests | ⚠️ | 12/15 tasks mapped to executable test evidence; 3 tasks are review/verification tasks (4.3, 5.1, 5.2) with no RED cycle |
+| RED confirmed (tests exist) | ✅ | Test files referenced in TDD table exist in repository |
+| GREEN confirmed (tests pass) | ✅ | Referenced test suites pass on current execution |
+| Triangulation adequate | ✅ | Multi-case coverage present for middleware + callback branches and helper constants |
+| Safety Net for modified files | ✅ | Modified files show safety-net runs; `N/A (new)` only used for new helper test file |
+
+**TDD Compliance**: 5/6 checks passed
+
+---
+
+### Test Layer Distribution
+| Layer | Tests | Files | Tools |
+|-------|-------|-------|-------|
+| Unit | 2 | 1 | `go test` |
+| Integration | 30 | 3 | `go test` + `httptest` + Gin handlers |
+| E2E | 0 | 0 | not installed |
+| **Total** | **32** | **4** | |
+
+---
+
+### Changed File Coverage
+| File | Line % | Branch % | Uncovered Lines | Rating |
+|------|--------|----------|-----------------|--------|
+| `pkg/auth_error.go` | 100% | N/A | — | ✅ Excellent |
+| `pkg/security-middleware.go` | 100% | N/A | — | ✅ Excellent |
+| `internal/infrastructure/port/in/google/routes.go` | 100% | N/A | — | ✅ Excellent |
+| `internal/infrastructure/port/in/me/routes.go` | 100% | N/A | — | ✅ Excellent |
+
+**Average changed file coverage (production files)**: 100%
+
+---
+
+### Assertion Quality
+**Assertion quality**: ✅ All assertions verify real behavior
+
+---
+
+### Quality Metrics
+**Linter**: ➖ Not available (per cached capabilities)
+**Type Checker**: ✅ No errors (`go vet ./...`)
+
+---
+
+### Spec Compliance Matrix
+
+| Requirement | Scenario | Test | Result |
+|-------------|----------|------|--------|
+| Canonical Auth Error Envelope | Middleware auth failure uses canonical envelope | `pkg/security-middleware_test.go > TestAuthMiddleware_MissingToken` (plus invalid/expired token tests) | ✅ COMPLIANT |
+| Auth Error Codes Are Stable and Branch-Specific | Missing token maps to stable code | `pkg/security-middleware_test.go > TestAuthMiddleware_MissingToken` | ✅ COMPLIANT |
+| Auth Error Codes Are Stable and Branch-Specific | Invalid token maps to stable code | `pkg/security-middleware_test.go > TestAuthMiddleware_ExpiredToken`, `TestAuthMiddleware_MalformedToken` | ✅ COMPLIANT |
+| Messages Are Client-Safe and Actionable | Message omits internal details | `pkg/security-middleware_test.go` + `internal/infrastructure/port/in/google/routes_test.go > TestGoogleCallbackHandler_ProviderError`, `TestGoogleCallbackHandler_TokenGenerationError` | ✅ COMPLIANT |
+| Unauthorized Payload Remains Clear and Actionable | Disallowed email returns canonical auth envelope | `internal/infrastructure/port/in/google/routes_test.go > TestGoogleCallbackHandler_EmailNotAllowed` | ✅ COMPLIANT |
+| Unauthorized Payload Remains Clear and Actionable | Callback auth failure payload remains unambiguous | `internal/infrastructure/port/in/google/routes_test.go > TestGoogleCallbackHandler_{InvalidState,MissingCode,ProviderError,EmailNotAllowed,TokenGenerationError}` | ✅ COMPLIANT |
+| Callback Test Suite Reflects Unauthorized Contract | Tests assert standardized callback auth error contract | `internal/infrastructure/port/in/google/routes_test.go` (auth failure table/subtests) | ✅ COMPLIANT |
+| Callback Test Suite Reflects Unauthorized Contract | Success flow regression guard remains intact | `internal/infrastructure/port/in/google/routes_test.go > TestGoogleCallbackHandler_Success_NoRedirect`, `TestGoogleCallbackHandler_Success_WithRedirect` | ✅ COMPLIANT |
+
+**Compliance summary**: 8/8 scenarios compliant
+
+---
+
+### Correctness (Static — Structural Evidence)
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| Canonical envelope (`code`,`message` only) | ✅ Implemented | `pkg.WriteAuthError` enforces two-field payload; middleware/google/me auth branches use helper |
+| Stable branch-specific auth codes | ✅ Implemented | Constants in `pkg/auth_error.go` are snake_case and asserted in tests |
+| Client-safe actionable messages | ✅ Implemented | Messages are generic and do not expose internal/provider internals |
+| Callback contract and success behavior | ✅ Implemented | Failure branches standardized; success token/cookie + redirect behavior preserved |
+
+---
+
+### Coherence (Design)
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| Centralize auth error envelope via shared helper | ✅ Yes | `pkg/auth_error.go` created and reused by middleware/handlers |
+| Stable auth code taxonomy | ✅ Yes | Code constants and tests added; branch mappings implemented |
+| File changes align with design table | ✅ Yes | All listed target files changed, including conditional `me` alignment |
+| Contract snippet naming alignment | ⚠️ Partial | Design snippet still shows uppercase code examples while implementation/spec use snake_case |
+
+---
+
+### Issues Found
+
+**CRITICAL** (must fix before archive):
+- None
+
+**WARNING** (should fix):
+- TDD evidence table includes non-test tasks (4.3, 5.1, 5.2) without full RED entries; acceptable for review tasks but not strict RED/GREEN format.
+- Design doc contract snippet (`design.md`) is stale regarding code naming examples (uppercase vs implemented snake_case), creating documentation drift.
+
+**SUGGESTION** (nice to have):
+- Add an explicit filesystem `apply-progress.md` under the active OpenSpec change folder for complete hybrid audit parity (currently evidence was retrieved from Engram artifact).
+
+---
+
+### Verdict
+PASS WITH WARNINGS
+
+Implementation is behaviorally compliant with all spec scenarios (8/8), tests and type checks pass, and strict-TDD evidence is largely validated with minor documentation/process drift warnings.

--- a/openspec/specs/auth-error-payloads/spec.md
+++ b/openspec/specs/auth-error-payloads/spec.md
@@ -1,0 +1,47 @@
+# Auth Error Payloads Specification
+
+## Purpose
+
+Define a canonical auth error payload contract so auth failures are machine-readable and consistent across middleware and auth-scoped endpoints.
+
+## Requirements
+
+### Requirement: Canonical Auth Error Envelope
+
+The system MUST return auth failures as a JSON object containing exactly `code` and `message` fields.
+
+#### Scenario: Middleware auth failure uses canonical envelope
+
+- GIVEN an auth request evaluated by middleware
+- WHEN the request is rejected for authentication reasons
+- THEN the response body MUST include `code` and `message`
+- AND the response body MUST NOT include legacy `error` as the contract field
+
+### Requirement: Auth Error Codes Are Stable and Branch-Specific
+
+The system SHALL use stable, branch-specific auth error codes so clients can reliably branch on failure type across releases.
+
+#### Scenario: Missing token maps to stable code
+
+- GIVEN a protected route request with no token
+- WHEN middleware rejects the request
+- THEN status MUST be `401`
+- AND `code` SHALL be `auth_token_missing`
+
+#### Scenario: Invalid token maps to stable code
+
+- GIVEN a protected route request with an invalid token
+- WHEN middleware rejects the request
+- THEN status MUST be `401`
+- AND `code` SHALL be `auth_token_invalid`
+
+### Requirement: Messages Are Client-Safe and Actionable
+
+The system MUST provide a client-safe `message` suitable for user/client handling and MUST NOT expose internal stack or provider internals in auth error responses.
+
+#### Scenario: Message omits internal details
+
+- GIVEN an auth-scoped endpoint returns an auth failure
+- WHEN the response is serialized
+- THEN `message` MUST describe the failure class in user-safe terms
+- AND `message` MUST NOT include internal stack traces, secrets, or provider internals

--- a/openspec/specs/google-oauth-callback/spec.md
+++ b/openspec/specs/google-oauth-callback/spec.md
@@ -19,25 +19,34 @@ The system MUST return HTTP `401 Unauthorized` when the Google OAuth callback re
 
 ### Requirement: Unauthorized Payload Remains Clear and Actionable
 
-The system MUST preserve a clear, actionable response payload for disallowed-email callback responses; the payload semantics SHOULD remain unchanged except for status alignment to `401`.
+The system MUST return the standardized auth error envelope for auth-related callback failures, with clear and actionable client-safe semantics.
+(Previously: Payload meaning stayed implicit and tied to legacy error-string semantics.)
 
-#### Scenario: Payload clarity for disallowed email
+#### Scenario: Disallowed email returns canonical auth envelope
 
 - GIVEN a callback request that reaches the disallowed-email branch
 - WHEN the handler returns unauthorized
-- THEN the response payload MUST include the same explicit disallowed-email meaning used previously
-- AND clients SHALL be able to identify the response as an authorization failure without ambiguity
+- THEN the response status SHALL be `401`
+- AND the payload MUST include `code=auth_email_not_allowed` and a client-safe `message`
+
+#### Scenario: Callback auth failure payload remains unambiguous
+
+- GIVEN a callback request that reaches an auth-related failure branch
+- WHEN the handler returns an auth failure response
+- THEN the payload MUST use `code` and `message` fields
+- AND clients SHALL identify authorization failure type from `code` without parsing free text
 
 ### Requirement: Callback Test Suite Reflects Unauthorized Contract
 
-The callback test suite MUST assert `401` for disallowed-email outcomes and MUST continue to cover both success and error branches.
+The callback test suite MUST assert standardized auth error envelope behavior for auth-related callback failures while continuing to cover success and error branches.
+(Previously: Tests asserted unauthorized status and payload clarity, but not stable envelope fields/codes.)
 
-#### Scenario: Test expectation updated for disallowed email
+#### Scenario: Tests assert standardized callback auth error contract
 
-- GIVEN callback tests for disallowed-email handling
+- GIVEN callback tests for disallowed-email and other auth-related failure handling
 - WHEN tests execute against current callback behavior
-- THEN expected status MUST be `401`
-- AND assertions for payload clarity SHALL remain validated
+- THEN expected payload assertions MUST include `code` and `message`
+- AND expected status/code pairs SHALL be validated for each covered branch
 
 #### Scenario: Success flow regression guard remains intact
 

--- a/pkg/auth_error.go
+++ b/pkg/auth_error.go
@@ -1,0 +1,27 @@
+package pkg
+
+import "github.com/gin-gonic/gin"
+
+const (
+	AuthCodeTokenMissing          = "auth_token_missing"
+	AuthCodeTokenInvalid          = "auth_token_invalid"
+	AuthCodeCallbackStateInvalid  = "auth_callback_state_invalid"
+	AuthCodeCallbackCodeMissing   = "auth_callback_code_missing"
+	AuthCodeEmailNotAllowed       = "auth_email_not_allowed"
+	AuthCodeProviderFailure       = "auth_provider_failure"
+	AuthCodeTokenGenerationFailed = "auth_token_generation_failed"
+	AuthCodeClaimsMissing         = "auth_claims_missing"
+	AuthCodeClaimsInvalid         = "auth_claims_invalid"
+)
+
+type AuthErrorResponse struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func WriteAuthError(ctx *gin.Context, status int, code, message string) {
+	ctx.JSON(status, AuthErrorResponse{
+		Code:    code,
+		Message: message,
+	})
+}

--- a/pkg/auth_error_test.go
+++ b/pkg/auth_error_test.go
@@ -1,0 +1,82 @@
+package pkg
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteAuthError(t *testing.T) {
+	testCases := []struct {
+		name           string
+		status         int
+		code           string
+		message        string
+		expectedStatus int
+	}{
+		{
+			name:           "writes unauthorized token missing payload",
+			status:         http.StatusUnauthorized,
+			code:           AuthCodeTokenMissing,
+			message:        "missing authentication token",
+			expectedStatus: http.StatusUnauthorized,
+		},
+		{
+			name:           "writes internal provider failure payload",
+			status:         http.StatusInternalServerError,
+			code:           AuthCodeProviderFailure,
+			message:        "authentication provider unavailable",
+			expectedStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			ctx, _ := gin.CreateTestContext(w)
+
+			WriteAuthError(ctx, tc.status, tc.code, tc.message)
+
+			assert.Equal(t, tc.expectedStatus, w.Code)
+
+			var payload map[string]string
+			err := json.Unmarshal(w.Body.Bytes(), &payload)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.code, payload["code"])
+			assert.Equal(t, tc.message, payload["message"])
+			assert.Len(t, payload, 2)
+			_, hasLegacyError := payload["error"]
+			assert.False(t, hasLegacyError)
+		})
+	}
+}
+
+func TestAuthErrorCodes_AreStableAndSnakeCase(t *testing.T) {
+	testCases := []struct {
+		name     string
+		actual   string
+		expected string
+	}{
+		{name: "token missing", actual: AuthCodeTokenMissing, expected: "auth_token_missing"},
+		{name: "token invalid", actual: AuthCodeTokenInvalid, expected: "auth_token_invalid"},
+		{name: "callback state invalid", actual: AuthCodeCallbackStateInvalid, expected: "auth_callback_state_invalid"},
+		{name: "callback code missing", actual: AuthCodeCallbackCodeMissing, expected: "auth_callback_code_missing"},
+		{name: "email not allowed", actual: AuthCodeEmailNotAllowed, expected: "auth_email_not_allowed"},
+		{name: "provider failure", actual: AuthCodeProviderFailure, expected: "auth_provider_failure"},
+		{name: "token generation failed", actual: AuthCodeTokenGenerationFailed, expected: "auth_token_generation_failed"},
+		{name: "claims missing", actual: AuthCodeClaimsMissing, expected: "auth_claims_missing"},
+		{name: "claims invalid", actual: AuthCodeClaimsInvalid, expected: "auth_claims_invalid"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.actual)
+		})
+	}
+}

--- a/pkg/security-middleware.go
+++ b/pkg/security-middleware.go
@@ -26,17 +26,15 @@ func (app *Application) AuthMiddleware() gin.HandlerFunc {
 
 		token := extractToken(c)
 		if token == "" {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
-				"error": "missing authentication token",
-			})
+			WriteAuthError(c, http.StatusUnauthorized, AuthCodeTokenMissing, "missing authentication token")
+			c.Abort()
 			return
 		}
 
 		claims, err := app.validateToken(token)
 		if err != nil {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
-				"error": "invalid or expired token",
-			})
+			WriteAuthError(c, http.StatusUnauthorized, AuthCodeTokenInvalid, "invalid or expired token")
+			c.Abort()
 			return
 		}
 

--- a/pkg/security-middleware_test.go
+++ b/pkg/security-middleware_test.go
@@ -3,6 +3,7 @@ package pkg
 import (
 	"crypto/rand"
 	"crypto/rsa"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -14,6 +15,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func decodeAuthErrorPayload(t *testing.T, body []byte) map[string]string {
+	t.Helper()
+
+	var payload map[string]string
+	err := json.Unmarshal(body, &payload)
+	require.NoError(t, err)
+
+	return payload
+}
 
 func init() {
 	gin.SetMode(gin.TestMode)
@@ -120,7 +131,12 @@ func TestAuthMiddleware_MissingToken(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
-	assert.Contains(t, w.Body.String(), "missing authentication token")
+	payload := decodeAuthErrorPayload(t, w.Body.Bytes())
+	assert.Equal(t, AuthCodeTokenMissing, payload["code"])
+	assert.Equal(t, "missing authentication token", payload["message"])
+	assert.Len(t, payload, 2)
+	_, hasLegacyError := payload["error"]
+	assert.False(t, hasLegacyError)
 }
 
 func TestAuthMiddleware_ValidTokenInHeader(t *testing.T) {
@@ -233,7 +249,12 @@ func TestAuthMiddleware_ExpiredToken(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
-	assert.Contains(t, w.Body.String(), "invalid or expired token")
+	payload := decodeAuthErrorPayload(t, w.Body.Bytes())
+	assert.Equal(t, AuthCodeTokenInvalid, payload["code"])
+	assert.Equal(t, "invalid or expired token", payload["message"])
+	assert.Len(t, payload, 2)
+	_, hasLegacyError := payload["error"]
+	assert.False(t, hasLegacyError)
 }
 
 func TestAuthMiddleware_InvalidIssuer(t *testing.T) {
@@ -315,7 +336,12 @@ func TestAuthMiddleware_MalformedToken(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
-	assert.Contains(t, w.Body.String(), "invalid or expired token")
+	payload := decodeAuthErrorPayload(t, w.Body.Bytes())
+	assert.Equal(t, AuthCodeTokenInvalid, payload["code"])
+	assert.Equal(t, "invalid or expired token", payload["message"])
+	assert.Len(t, payload, 2)
+	_, hasLegacyError := payload["error"]
+	assert.False(t, hasLegacyError)
 }
 
 func TestAuthMiddleware_InvalidAuthorizationFormat(t *testing.T) {
@@ -333,7 +359,12 @@ func TestAuthMiddleware_InvalidAuthorizationFormat(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
-	assert.Contains(t, w.Body.String(), "missing authentication token")
+	payload := decodeAuthErrorPayload(t, w.Body.Bytes())
+	assert.Equal(t, AuthCodeTokenMissing, payload["code"])
+	assert.Equal(t, "missing authentication token", payload["message"])
+	assert.Len(t, payload, 2)
+	_, hasLegacyError := payload["error"]
+	assert.False(t, hasLegacyError)
 }
 
 func TestAuthMiddleware_HeaderTakesPrecedenceOverCookie(t *testing.T) {


### PR DESCRIPTION
Closes #4

## Summary
- Standardizes auth-related error responses to a single JSON contract with stable `code` + `message` fields.
- Applies the shared auth error envelope across middleware, Google OAuth callback failure paths, and `/me` auth-claims fallback branches.
- Updates tests to assert exact contract semantics and archives full SDD artifacts/spec merges for issue 4.

## Changes
| File | Change |
|------|--------|
| `pkg/auth_error.go` | Adds canonical auth error payload helper and stable auth error codes. |
| `pkg/auth_error_test.go` | Adds table-driven tests for payload shape, status mapping, and code stability. |
| `pkg/security-middleware.go` | Replaces legacy `{error: ...}` unauthorized responses with standardized `code/message` envelope. |
| `pkg/security-middleware_test.go` | Asserts exact contract (`code`, `message`, no `error`) for auth middleware failure scenarios. |
| `internal/infrastructure/port/in/google/routes.go` | Standardizes callback auth-related failures (state/code/provider/email/token generation) to shared envelope. |
| `internal/infrastructure/port/in/google/routes_test.go` | Updates callback failure tests to assert standardized contract and branch-specific codes. |
| `internal/infrastructure/port/in/me/routes.go` | Standardizes missing/invalid claims fallback responses to shared envelope. |
| `internal/infrastructure/port/in/me/routes_test.go` | Adds strict contract assertions for `/me` fallback auth failures. |
| `openspec/specs/auth-error-payloads/spec.md` | Adds merged spec for standardized auth error payload capability. |
| `openspec/specs/google-oauth-callback/spec.md` | Updates callback spec requirements to standardized auth error envelope. |
| `openspec/changes/archive/2026-04-25-issue-4-standardize-auth-error-payloads/*` | Archives proposal/spec/design/tasks/verify reports for the completed SDD change. |

## Test Plan
- [x] `go test ./...`
- [x] `go test ./... -cover`
- [x] `go vet ./...`

## Checklist
- [x] Linked approved issue (`Closes #4`)
- [x] Conventional commit messages used
- [x] Tests updated for contract consistency
- [x] OpenSpec artifacts/specs updated and archived (hybrid SDD)