### PR TITLE
refactor: migrate to common-fwk v0.10.0, eliminate Bootstrap and manual RSA wiring

### DIFF
--- a/bruno/Auth-Provider/Healthz.bru
+++ b/bruno/Auth-Provider/Healthz.bru
@@ -1,0 +1,16 @@
+meta {
+  name: Healthz
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{auth-provider-url}}/healthz
+  body: none
+  auth: inherit
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/bruno/Auth-Provider/Readyz.bru
+++ b/bruno/Auth-Provider/Readyz.bru
@@ -1,11 +1,11 @@
 meta {
-  name: Ping
+  name: Readyz
   type: http
-  seq: 1
+  seq: 5
 }
 
 get {
-  url: {{auth-provider-url}}/ping
+  url: {{auth-provider-url}}/readyz
   body: none
   auth: inherit
 }

--- a/cmd/provider-auth-ms/config.yaml
+++ b/cmd/provider-auth-ms/config.yaml
@@ -8,13 +8,11 @@ server:
 security:
   auth:
     jwt:
-      # algorithm: RS256 wiring via UseServerSecurityFromConfig() is blocked pending
-      # common-fwk exposing the generated RSA keypair for JWKS usage.
-      # JWT security is wired manually in main.go using fwkkeys/fwkjwt directly.
-      # See: https://github.com/matiasmartin-labs/common-fwk/issues/50
+      algorithm: RS256
       issuer: auth-provider-ms
       ttl-minutes: 60
-      secret: ${JWT_SECRET}
+      rs256-key-source: generated
+      rs256-key-id: auth-provider-ms-key
     cookie:
       name: token
       domain: ""

--- a/cmd/provider-auth-ms/config.yaml
+++ b/cmd/provider-auth-ms/config.yaml
@@ -8,9 +8,13 @@ server:
 security:
   auth:
     jwt:
-      algorithm: RS256
+      # algorithm: RS256 wiring via UseServerSecurityFromConfig() is blocked pending
+      # common-fwk exposing the generated RSA keypair for JWKS usage.
+      # JWT security is wired manually in main.go using fwkkeys/fwkjwt directly.
+      # See: https://github.com/matiasmartin-labs/common-fwk/issues/50
       issuer: auth-provider-ms
       ttl-minutes: 60
+      secret: ${JWT_SECRET}
     cookie:
       name: token
       domain: ""

--- a/cmd/provider-auth-ms/config.yaml
+++ b/cmd/provider-auth-ms/config.yaml
@@ -1,29 +1,40 @@
 server:
   host: ""
   port: 8080
+  read-timeout: 10s
+  write-timeout: 10s
+  max-header-bytes: 1048576
 
 security:
   auth:
     jwt:
-      secret: ${JWT_SECRET}
+      algorithm: RS256
       issuer: auth-provider-ms
-      ttlMinutes: 60
+      ttl-minutes: 60
     cookie:
       name: token
       domain: ""
       secure: false
-      httpOnly: true
-      sameSite: Strict
+      http-only: true
+      same-site: Strict
     login:
       email: ${ALLOWED_EMAILS}
     oauth2:
       providers:
         google:
-          clientID: ${GOOGLE_CLIENT_ID}
-          clientSecret: ${GOOGLE_CLIENT_SECRET}
-          authURL: https://accounts.google.com/o/oauth2/auth
-          tokenURL: https://oauth2.googleapis.com/token
-          redirectURL: http://localhost:8080/login/oauth2/code/google
+          client-id: ${GOOGLE_CLIENT_ID}
+          client-secret: ${GOOGLE_CLIENT_SECRET}
+          auth-url: https://accounts.google.com/o/oauth2/auth
+          token-url: https://oauth2.googleapis.com/token
+          redirect-url: http://localhost:8080/login/oauth2/code/google
           scopes:
             - https://www.googleapis.com/auth/userinfo.email
             - https://www.googleapis.com/auth/userinfo.profile
+
+logging:
+  enabled: true
+  level: info
+  format: json
+  loggers:
+    auth:
+      level: debug

--- a/cmd/provider-auth-ms/main.go
+++ b/cmd/provider-auth-ms/main.go
@@ -1,14 +1,16 @@
 package main
 
 import (
-	"flag"
 	"crypto/rand"
 	"crypto/rsa"
+	"flag"
 	"log"
 	"os"
 
 	fwkapp "github.com/matiasmartin-labs/common-fwk/app"
 	fwkviper "github.com/matiasmartin-labs/common-fwk/config/viper"
+	fwkjwt "github.com/matiasmartin-labs/common-fwk/security/jwt"
+	fwkkeys "github.com/matiasmartin-labs/common-fwk/security/keys"
 
 	"github.com/matiasmartin-labs/auth-provider-ms/internal/infrastructure/port/in/jwks"
 	"github.com/matiasmartin-labs/auth-provider-ms/internal/infrastructure/port/in/server"
@@ -32,22 +34,33 @@ func main() {
 	}
 
 	// ---- RSA keypair ----
+	// NOTE: we generate the keypair here (not via UseServerSecurityFromConfig) because
+	// the app needs direct access to the private key to sign tokens and the public key
+	// to expose it via the JWKS endpoint. common-fwk v0.4.0 does not expose the
+	// internally generated RSA keypair when using rs256-key-source: generated.
+	// See: https://github.com/matiasmartin-labs/common-fwk/issues/50
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		log.Fatalf("generate rsa key: %v", err)
 	}
 	keyPair := jwks.NewKeyPair(privateKey)
 
+	// ---- JWT validator ----
+	resolver := fwkkeys.NewRSAResolver(privateKey, keyPair.KeyID)
+	validator, err := fwkjwt.NewValidator(fwkjwt.Options{
+		Methods:  []string{"RS256"},
+		Issuer:   cfg.Security.Auth.JWT.Issuer,
+		Resolver: resolver,
+	})
+	if err != nil {
+		log.Fatalf("create validator: %v", err)
+	}
+
 	// ---- Application ----
 	application := fwkapp.NewApplication().
 		UseConfig(cfg).
-		UseServer()
-
-	// ---- Security (v0.4.0: config-based RS256 wiring) ----
-	application, err = application.UseServerSecurityFromConfig()
-	if err != nil {
-		log.Fatalf("wire security from config: %v", err)
-	}
+		UseServer().
+		UseServerSecurity(validator)
 
 	// ---- Health/Readiness presets (v0.6.0) ----
 	if err := application.EnableHealthReadinessPresets(fwkapp.HealthReadinessOptions{}); err != nil {

--- a/cmd/provider-auth-ms/main.go
+++ b/cmd/provider-auth-ms/main.go
@@ -9,8 +9,6 @@ import (
 
 	fwkapp "github.com/matiasmartin-labs/common-fwk/app"
 	fwkviper "github.com/matiasmartin-labs/common-fwk/config/viper"
-	fwkjwt "github.com/matiasmartin-labs/common-fwk/security/jwt"
-	fwkkeys "github.com/matiasmartin-labs/common-fwk/security/keys"
 
 	"github.com/matiasmartin-labs/auth-provider-ms/internal/infrastructure/port/in/jwks"
 	"github.com/matiasmartin-labs/auth-provider-ms/internal/infrastructure/port/in/server"
@@ -40,15 +38,26 @@ func main() {
 	}
 	keyPair := jwks.NewKeyPair(privateKey)
 
-	// ---- JWT validator ----
-	resolver := fwkkeys.NewRSAResolver(privateKey, keyPair.KeyID)
-	validator, err := fwkjwt.NewValidator(fwkjwt.Options{
-		Methods:  []string{"RS256"},
-		Issuer:   cfg.Security.Auth.JWT.Issuer,
-		Resolver: resolver,
-	})
+	// ---- Application ----
+	application := fwkapp.NewApplication().
+		UseConfig(cfg).
+		UseServer()
+
+	// ---- Security (v0.4.0: config-based RS256 wiring) ----
+	application, err = application.UseServerSecurityFromConfig()
 	if err != nil {
-		log.Fatalf("create validator: %v", err)
+		log.Fatalf("wire security from config: %v", err)
+	}
+
+	// ---- Health/Readiness presets (v0.6.0) ----
+	if err := application.EnableHealthReadinessPresets(fwkapp.HealthReadinessOptions{}); err != nil {
+		log.Fatalf("enable health/readiness: %v", err)
+	}
+
+	// ---- Logger (v0.7.0) ----
+	logger, err := application.GetLogger("auth")
+	if err != nil {
+		log.Fatalf("get logger: %v", err)
 	}
 
 	// ---- Bootstrap ----
@@ -56,19 +65,16 @@ func main() {
 		PrivateKey: privateKey,
 		KeyPair:    keyPair,
 		Config:     cfg,
+		Logger:     logger,
 	}
 
-	// ---- Application ----
-	app := fwkapp.NewApplication().
-		UseConfig(cfg).
-		UseServer().
-		UseServerSecurity(validator)
-
-	if err := server.Routes(app, b); err != nil {
+	if err := server.Routes(application, b); err != nil {
 		log.Fatalf("register routes: %v", err)
 	}
 
-	if err := app.Run(); err != nil {
+	logger.Infof("starting auth-provider-ms on port %d", cfg.Server.Port)
+
+	if err := application.Run(); err != nil {
 		log.Fatalf("run: %v", err)
 	}
 }

--- a/cmd/provider-auth-ms/main.go
+++ b/cmd/provider-auth-ms/main.go
@@ -1,18 +1,13 @@
 package main
 
 import (
-	"crypto/rand"
-	"crypto/rsa"
 	"flag"
 	"log"
 	"os"
 
 	fwkapp "github.com/matiasmartin-labs/common-fwk/app"
 	fwkviper "github.com/matiasmartin-labs/common-fwk/config/viper"
-	fwkjwt "github.com/matiasmartin-labs/common-fwk/security/jwt"
-	fwkkeys "github.com/matiasmartin-labs/common-fwk/security/keys"
 
-	"github.com/matiasmartin-labs/auth-provider-ms/internal/infrastructure/port/in/jwks"
 	"github.com/matiasmartin-labs/auth-provider-ms/internal/infrastructure/port/in/server"
 )
 
@@ -33,55 +28,30 @@ func main() {
 		log.Fatalf("load config: %v", err)
 	}
 
-	// ---- RSA keypair ----
-	// NOTE: we generate the keypair here (not via UseServerSecurityFromConfig) because
-	// the app needs direct access to the private key to sign tokens and the public key
-	// to expose it via the JWKS endpoint. common-fwk v0.4.0 does not expose the
-	// internally generated RSA keypair when using rs256-key-source: generated.
-	// See: https://github.com/matiasmartin-labs/common-fwk/issues/50
-	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		log.Fatalf("generate rsa key: %v", err)
-	}
-	keyPair := jwks.NewKeyPair(privateKey)
-
-	// ---- JWT validator ----
-	resolver := fwkkeys.NewRSAResolver(privateKey, keyPair.KeyID)
-	validator, err := fwkjwt.NewValidator(fwkjwt.Options{
-		Methods:  []string{"RS256"},
-		Issuer:   cfg.Security.Auth.JWT.Issuer,
-		Resolver: resolver,
-	})
-	if err != nil {
-		log.Fatalf("create validator: %v", err)
-	}
-
 	// ---- Application ----
 	application := fwkapp.NewApplication().
 		UseConfig(cfg).
-		UseServer().
-		UseServerSecurity(validator)
+		UseServer()
 
-	// ---- Health/Readiness presets (v0.6.0) ----
+	// ---- Security (v0.9.0: config-based RS256 wiring, exposes GetRSAPrivateKey) ----
+	application, err = application.UseServerSecurityFromConfig()
+	if err != nil {
+		log.Fatalf("wire security from config: %v", err)
+	}
+
+	// ---- Health/Readiness presets ----
 	if err := application.EnableHealthReadinessPresets(fwkapp.HealthReadinessOptions{}); err != nil {
 		log.Fatalf("enable health/readiness: %v", err)
 	}
 
-	// ---- Logger (v0.7.0) ----
+	// ---- Logger ----
 	logger, err := application.GetLogger("auth")
 	if err != nil {
 		log.Fatalf("get logger: %v", err)
 	}
 
-	// ---- Bootstrap ----
-	b := &server.Bootstrap{
-		PrivateKey: privateKey,
-		KeyPair:    keyPair,
-		Config:     cfg,
-		Logger:     logger,
-	}
-
-	if err := server.Routes(application, b); err != nil {
+	// ---- Routes ----
+	if err := server.Routes(application); err != nil {
 		log.Fatalf("register routes: %v", err)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 require (
 	cloud.google.com/go/compute/metadata v0.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/matiasmartin-labs/common-fwk v0.1.0 // indirect
+	github.com/matiasmartin-labs/common-fwk v0.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 require (
 	cloud.google.com/go/compute/metadata v0.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/matiasmartin-labs/common-fwk v0.7.0 // indirect
+	github.com/matiasmartin-labs/common-fwk v0.10.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/matiasmartin-labs/common-fwk v0.1.0 h1:pP6B4fV7uXVZ+/1C1I/B84M+n2ycTv
 github.com/matiasmartin-labs/common-fwk v0.1.0/go.mod h1:lZMlKaenV0KFr5kxHfWjH34b5kfApILBF+b0ZnmcF78=
 github.com/matiasmartin-labs/common-fwk v0.7.0 h1:WCwnI7g++0KRsUI63q8d9n54yhIigud66pflylpOWwE=
 github.com/matiasmartin-labs/common-fwk v0.7.0/go.mod h1:lZMlKaenV0KFr5kxHfWjH34b5kfApILBF+b0ZnmcF78=
+github.com/matiasmartin-labs/common-fwk v0.10.0 h1:i4v8XZIrq7ehEhwDcWDzUqIL6MwmyG1Qi7mffuIf7+w=
+github.com/matiasmartin-labs/common-fwk v0.10.0/go.mod h1:lZMlKaenV0KFr5kxHfWjH34b5kfApILBF+b0ZnmcF78=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/lestrrat-go/option v1.0.1 h1:oAzP2fvZGQKWkvHa1/SAcFolBEca1oN+mQ7eooNB
 github.com/lestrrat-go/option v1.0.1/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
 github.com/matiasmartin-labs/common-fwk v0.1.0 h1:pP6B4fV7uXVZ+/1C1I/B84M+n2ycTv8s1bTbc5DfaYo=
 github.com/matiasmartin-labs/common-fwk v0.1.0/go.mod h1:lZMlKaenV0KFr5kxHfWjH34b5kfApILBF+b0ZnmcF78=
+github.com/matiasmartin-labs/common-fwk v0.7.0 h1:WCwnI7g++0KRsUI63q8d9n54yhIigud66pflylpOWwE=
+github.com/matiasmartin-labs/common-fwk v0.7.0/go.mod h1:lZMlKaenV0KFr5kxHfWjH34b5kfApILBF+b0ZnmcF78=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/internal/infrastructure/port/in/jwks/routes.go
+++ b/internal/infrastructure/port/in/jwks/routes.go
@@ -25,15 +25,23 @@ func NewKeyPair(privateKey *rsa.PrivateKey) *KeyPair {
 }
 
 // NewJwksHandler returns a Gin handler that serves the RSA public key as a JWKS JSON response.
+//
+// Deprecated: prefer NewJwksHandlerFromPublicKey, which accepts the public key and
+// key ID directly so that KeyPair is no longer required.
 func NewJwksHandler(kp *KeyPair) gin.HandlerFunc {
-	return func(ctx *gin.Context) {
-		pub := &kp.PrivateKey.PublicKey
+	return NewJwksHandlerFromPublicKey(&kp.PrivateKey.PublicKey, kp.KeyID)
+}
 
+// NewJwksHandlerFromPublicKey returns a Gin handler that serves pub as a JWKS JSON response
+// identified by keyID. Use this variant together with app.GetRSAPublicKey() and app.GetRSAKeyID()
+// so that the local KeyPair wrapper is not needed.
+func NewJwksHandlerFromPublicKey(pub *rsa.PublicKey, keyID string) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
 		ctx.JSON(200, gin.H{
 			"keys": []gin.H{
 				{
 					"kty": "RSA",
-					"kid": kp.KeyID,
+					"kid": keyID,
 					"use": "sig",
 					"alg": "RS256",
 					"n":   base64URLEncode(pub.N),

--- a/internal/infrastructure/port/in/server/server.go
+++ b/internal/infrastructure/port/in/server/server.go
@@ -7,6 +7,7 @@ import (
 
 	fwkapp "github.com/matiasmartin-labs/common-fwk/app"
 	fwkconfig "github.com/matiasmartin-labs/common-fwk/config"
+	fwklogging "github.com/matiasmartin-labs/common-fwk/logging"
 	"golang.org/x/oauth2"
 	googleoauth "golang.org/x/oauth2/google"
 
@@ -25,11 +26,13 @@ type Bootstrap struct {
 	PrivateKey *rsa.PrivateKey
 	KeyPair    *jwks.KeyPair
 	Config     fwkconfig.Config
+	Logger     fwklogging.Logger
 }
 
 // Routes wires all HTTP routes onto the application using the provided bootstrap.
 func Routes(app *fwkapp.Application, b *Bootstrap) error {
-	cfg := b.Config
+	// v0.5.0: use GetConfig() read-only accessor for runtime config snapshot
+	cfg := app.GetConfig()
 	googleProvider := cfg.Security.Auth.OAuth2.Providers["google"]
 	cookieCfg := cfg.Security.Auth.Cookie
 	jwtCfg := cfg.Security.Auth.JWT

--- a/internal/infrastructure/port/in/server/server.go
+++ b/internal/infrastructure/port/in/server/server.go
@@ -1,13 +1,10 @@
 package server
 
 import (
-	"crypto/rsa"
 	"strings"
 	"time"
 
 	fwkapp "github.com/matiasmartin-labs/common-fwk/app"
-	fwkconfig "github.com/matiasmartin-labs/common-fwk/config"
-	fwklogging "github.com/matiasmartin-labs/common-fwk/logging"
 	"golang.org/x/oauth2"
 	googleoauth "golang.org/x/oauth2/google"
 
@@ -21,17 +18,9 @@ import (
 
 const googleUserInfoURI = "https://www.googleapis.com/oauth2/v2/userinfo"
 
-// Bootstrap holds the runtime dependencies resolved at startup.
-type Bootstrap struct {
-	PrivateKey *rsa.PrivateKey
-	KeyPair    *jwks.KeyPair
-	Config     fwkconfig.Config
-	Logger     fwklogging.Logger
-}
-
-// Routes wires all HTTP routes onto the application using the provided bootstrap.
-func Routes(app *fwkapp.Application, b *Bootstrap) error {
-	// v0.5.0: use GetConfig() read-only accessor for runtime config snapshot
+// Routes wires all HTTP routes onto the application.
+// All runtime dependencies are resolved directly from app.Application.
+func Routes(app *fwkapp.Application) error {
 	cfg := app.GetConfig()
 	googleProvider := cfg.Security.Auth.OAuth2.Providers["google"]
 	cookieCfg := cfg.Security.Auth.Cookie
@@ -47,8 +36,9 @@ func Routes(app *fwkapp.Application, b *Bootstrap) error {
 
 	allowedEmails := resolveAllowedEmails(cfg.Security.Auth.Login.Email)
 
+	// v0.9.0: private key retrieved from Application — no manual keypair needed
 	tokenGen := token.NewJwtGenerator(token.JwtGeneratorConfig{
-		PrivateKey:     b.PrivateKey,
+		PrivateKey:     app.GetRSAPrivateKey(),
 		Issuer:         jwtCfg.Issuer,
 		Audience:       "auth-provider-clients",
 		ExpirationTime: time.Duration(jwtCfg.TTLMinutes) * time.Minute,
@@ -61,7 +51,7 @@ func Routes(app *fwkapp.Application, b *Bootstrap) error {
 		tokenGen,
 		googlein.GoogleOAuth2Config{
 			OAuth2Config:    oauth2Config,
-			State:           resolveState(googleProvider),
+			State:           "",
 			CookieName:      cookieCfg.Name,
 			CookieMaxAge:    0,
 			CookieSecure:    cookieCfg.Secure,
@@ -71,7 +61,8 @@ func Routes(app *fwkapp.Application, b *Bootstrap) error {
 		},
 	)
 
-	if err := app.RegisterGET("/.well-known/jwks.json", jwks.NewJwksHandler(b.KeyPair)); err != nil {
+	// v0.10.0: public key and key ID retrieved from Application — no jwks.KeyPair needed
+	if err := app.RegisterGET("/.well-known/jwks.json", jwks.NewJwksHandlerFromPublicKey(app.GetRSAPublicKey(), app.GetRSAKeyID())); err != nil {
 		return err
 	}
 	if err := app.RegisterGET("/login/oauth2/code/google", googleHandler.GoogleCallbackHandler); err != nil {
@@ -110,10 +101,4 @@ func resolveAllowedEmails(raw string) []string {
 	}
 
 	return out
-}
-
-// resolveState reads the OAuth2 state from the provider config.
-// common-fwk does not model state directly; fall back to empty string.
-func resolveState(_ fwkconfig.OAuth2ProviderConfig) string {
-	return ""
 }

--- a/internal/infrastructure/port/in/server/server_test.go
+++ b/internal/infrastructure/port/in/server/server_test.go
@@ -1,40 +1,44 @@
 package server
 
 import (
-	"crypto/rand"
-	"crypto/rsa"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	fwkapp "github.com/matiasmartin-labs/common-fwk/app"
 	fwkconfig "github.com/matiasmartin-labs/common-fwk/config"
-	fwkjwt "github.com/matiasmartin-labs/common-fwk/security/jwt"
-	fwkkeys "github.com/matiasmartin-labs/common-fwk/security/keys"
-	"github.com/matiasmartin-labs/auth-provider-ms/internal/infrastructure/port/in/jwks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func newTestBootstrap(t *testing.T) (*fwkapp.Application, *Bootstrap) {
+// newTestApp builds a fully wired Application for route tests using RS256 with
+// generated keys, mirroring the production config path.
+func newTestApp(t *testing.T) *fwkapp.Application {
 	t.Helper()
 
 	gin.SetMode(gin.TestMode)
 
-	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	require.NoError(t, err)
-
-	keyPair := jwks.NewKeyPair(privateKey)
-
 	cfg := fwkconfig.Config{
-		Server: fwkconfig.ServerConfig{Host: "127.0.0.1", Port: 8080},
+		Server: fwkconfig.ServerConfig{
+			Host:           "127.0.0.1",
+			Port:           8080,
+			ReadTimeout:    10 * time.Second,
+			WriteTimeout:   10 * time.Second,
+			MaxHeaderBytes: 1 << 20,
+		},
 		Security: fwkconfig.SecurityConfig{
 			Auth: fwkconfig.AuthConfig{
 				JWT: fwkconfig.JWTConfig{
+					Algorithm:  "RS256",
 					Issuer:     "test-issuer",
 					TTLMinutes: 60,
+					RS256: fwkconfig.RS256Config{
+						KeySource: fwkconfig.RS256KeySourceGenerated,
+						KeyID:     "test-key",
+					},
 				},
 				Cookie: fwkconfig.CookieConfig{
 					Name:     "token",
@@ -48,6 +52,8 @@ func newTestBootstrap(t *testing.T) (*fwkapp.Application, *Bootstrap) {
 							ClientID:     "test-client-id",
 							ClientSecret: "test-secret",
 							RedirectURL:  "http://localhost:8080/callback",
+							AuthURL:      "https://accounts.google.com/o/oauth2/auth",
+							TokenURL:     "https://oauth2.googleapis.com/token",
 							Scopes:       []string{"email", "profile"},
 						},
 					},
@@ -59,35 +65,21 @@ func newTestBootstrap(t *testing.T) (*fwkapp.Application, *Bootstrap) {
 		},
 	}
 
-	resolver := fwkkeys.NewRSAResolver(privateKey, keyPair.KeyID)
-	validator, err := fwkjwt.NewValidator(fwkjwt.Options{
-		Methods:  []string{"RS256"},
-		Issuer:   "test-issuer",
-		Resolver: resolver,
-	})
-	require.NoError(t, err)
-
-	b := &Bootstrap{
-		PrivateKey: privateKey,
-		KeyPair:    keyPair,
-		Config:     cfg,
-	}
-
-	app := fwkapp.NewApplication().
+	app, err := fwkapp.NewApplication().
 		UseConfig(cfg).
 		UseServer().
-		UseServerSecurity(validator)
+		UseServerSecurityFromConfig()
+	require.NoError(t, err)
 
-	return app, b
+	return app
 }
 
 func TestRoutes_RegistersSignOutEndpoint(t *testing.T) {
-	app, b := newTestBootstrap(t)
+	app := newTestApp(t)
 
-	err := Routes(app, b)
+	err := Routes(app)
 	require.NoError(t, err)
 
-	// Use a test listener so we can exercise the actual handler via RunListener.
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
@@ -105,9 +97,9 @@ func TestRoutes_RegistersSignOutEndpoint(t *testing.T) {
 }
 
 func TestRoutes_RegistersJWKSEndpoint(t *testing.T) {
-	app, b := newTestBootstrap(t)
+	app := newTestApp(t)
 
-	err := Routes(app, b)
+	err := Routes(app)
 	require.NoError(t, err)
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -127,42 +119,31 @@ func TestRoutes_RegistersJWKSEndpoint(t *testing.T) {
 func TestRoutes_ReturnsError_WhenServerNotReady(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	require.NoError(t, err)
-
-	b := &Bootstrap{
-		PrivateKey: privateKey,
-		KeyPair:    jwks.NewKeyPair(privateKey),
-		Config:     fwkconfig.Config{},
-	}
-
 	// Application without UseServer() — server not ready.
 	app := fwkapp.NewApplication()
 
-	err = Routes(app, b)
+	err := Routes(app)
 	assert.Error(t, err)
 }
 
-// httpRecorder creates a single-request test server without the net/http/httptest.Server overhead.
-func httpRecorder(t *testing.T, app *fwkapp.Application, b *Bootstrap, method, path string) *httptest.ResponseRecorder {
+// httpRecorder creates a single-request test server and returns a recorder with the response code.
+func httpRecorder(t *testing.T, app *fwkapp.Application, method, path string) *httptest.ResponseRecorder {
 	t.Helper()
 
-	err := Routes(app, b)
+	err := Routes(app)
 	require.NoError(t, err)
 
 	w := httptest.NewRecorder()
 
-	// Launch a test listener to exercise the actual routes.
 	ln, lnErr := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, lnErr)
 	go func() { _ = app.RunListener(ln) }()
 	t.Cleanup(func() { _ = ln.Close() })
 
-	resp, err := http.NewRequest(method, "http://"+ln.Addr().String()+path, nil)
+	req, err := http.NewRequest(method, "http://"+ln.Addr().String()+path, nil)
 	require.NoError(t, err)
 
-	client := &http.Client{}
-	httpResp, err := client.Do(resp)
+	httpResp, err := (&http.Client{}).Do(req)
 	require.NoError(t, err)
 	defer httpResp.Body.Close()
 
@@ -172,7 +153,7 @@ func httpRecorder(t *testing.T, app *fwkapp.Application, b *Bootstrap, method, p
 }
 
 func TestRoutes_RegistersGoogleLoginEndpoint(t *testing.T) {
-	app, b := newTestBootstrap(t)
-	w := httpRecorder(t, app, b, http.MethodGet, "/oauth2/authorization/google")
+	app := newTestApp(t)
+	w := httpRecorder(t, app, http.MethodGet, "/oauth2/authorization/google")
 	assert.NotEqual(t, http.StatusNotFound, w.Code)
 }


### PR DESCRIPTION
Closes #13

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [x] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Upgrade `common-fwk` from `v0.7.0` to `v0.10.0`, adopting `GetRSAPrivateKey()`, `GetRSAPublicKey()`, and `GetRSAKeyID()` to eliminate all manual RSA keypair wiring
- Replace config-less manual security bootstrap with `UseServerSecurityFromConfig()` + RS256 config fields
- Delete `server.Bootstrap` struct entirely; `app.Application` is now the single runtime container

## Changes

| File | Change |
|------|--------|
| `go.mod` | `common-fwk v0.7.0 → v0.10.0` |
| `cmd/provider-auth-ms/config.yaml` | Added `algorithm: RS256`, `rs256-key-source: generated`, `rs256-key-id`; removed `secret: ${JWT_SECRET}` |
| `cmd/provider-auth-ms/main.go` | Replaced manual `fwkkeys`/`fwkjwt` wiring with `UseServerSecurityFromConfig()` |
| `internal/infrastructure/port/in/server/server.go` | Deleted `Bootstrap` struct; `Routes(app)` uses `GetRSAPrivateKey()`, `GetRSAPublicKey()`, `GetRSAKeyID()` |
| `internal/infrastructure/port/in/jwks/routes.go` | Added `NewJwksHandlerFromPublicKey(pub, keyID)`; deprecated `NewJwksHandler(kp)` |
| `internal/infrastructure/port/in/server/server_test.go` | Removed `Bootstrap`, `fwkjwt`, `fwkkeys`; uses `UseServerSecurityFromConfig()` with full RS256 config |

## Test Plan

- [x] `go build ./...` passes with no errors
- [x] `go test ./... -count=1` — all packages green
- [x] Manually verified JWKS, sign-out, and Google login routes register correctly