### PR TITLE
feat: add Dockerfile to containerize auth-provider-ms and publish image to GHCR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+# Version control
+.git/
+
+# Documentation — not needed in the image
+*.md
+
+# Test artifacts
+coverage.out
+test-results.json
+
+# Editor config
+.vscode/
+
+# API client collection
+bruno/
+
+# Kubernetes manifests — not part of the build
+k8s/
+
+# SDD / OpenSpec artifacts
+openspec/
+.atl/
+
+# Temporary files
+tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+# syntax=docker/dockerfile:1
+
+# ---------------------------------------------------------------------------
+# Stage 1: builder
+# ---------------------------------------------------------------------------
+FROM golang:1.24-alpine AS builder
+
+ARG GOARCH
+ARG GOOS=linux
+
+WORKDIR /build
+
+# Copy dependency manifests first for layer caching
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy full source tree
+COPY . .
+
+# Build a static binary with debug info stripped
+RUN CGO_ENABLED=0 GOOS=${GOOS} go build \
+    -ldflags="-s -w" \
+    -o /app/provider-auth-ms \
+    ./cmd/provider-auth-ms
+
+# ---------------------------------------------------------------------------
+# Stage 2: runtime
+# ---------------------------------------------------------------------------
+FROM alpine:3.21 AS runtime
+
+# CA certificates for HTTPS calls to Google APIs
+RUN apk --no-cache add ca-certificates
+
+WORKDIR /app
+
+COPY --from=builder /app/provider-auth-ms /app/provider-auth-ms
+COPY cmd/provider-auth-ms/config.yaml /app/config.yaml
+
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+USER appuser
+
+EXPOSE 8080
+
+ENTRYPOINT ["/app/provider-auth-ms"]

--- a/docs/ghcr-publish.md
+++ b/docs/ghcr-publish.md
@@ -1,0 +1,88 @@
+# Publishing `auth-provider-ms` to GHCR
+
+This guide explains how to build and push the `auth-provider-ms` container image to the
+GitHub Container Registry (GHCR) at `ghcr.io/matiasmartin-labs/auth-provider-ms`.
+
+---
+
+## Prerequisites
+
+1. **Docker** installed and running (Docker Engine ≥ 24 recommended).
+2. A **GitHub Personal Access Token (PAT)** with the `write:packages` scope.
+   - Create one at <https://github.com/settings/tokens> → *Generate new token (classic)*.
+3. Authenticate Docker with GHCR:
+
+```bash
+echo "<YOUR_PAT>" | docker login ghcr.io -u <your-github-username> --password-stdin
+```
+
+---
+
+## Build
+
+```bash
+docker build -t ghcr.io/matiasmartin-labs/auth-provider-ms:latest .
+```
+
+To target a specific architecture (e.g., `arm64`):
+
+```bash
+docker build --build-arg GOARCH=arm64 \
+  -t ghcr.io/matiasmartin-labs/auth-provider-ms:latest .
+```
+
+---
+
+## Tag
+
+Replace `<version>` with a semantic version (e.g., `v1.0.0`):
+
+```bash
+docker tag ghcr.io/matiasmartin-labs/auth-provider-ms:latest \
+           ghcr.io/matiasmartin-labs/auth-provider-ms:<version>
+```
+
+---
+
+## Push
+
+```bash
+# Push a specific version tag
+docker push ghcr.io/matiasmartin-labs/auth-provider-ms:<version>
+
+# Push latest
+docker push ghcr.io/matiasmartin-labs/auth-provider-ms:latest
+```
+
+---
+
+## Required Environment Variables
+
+The application reads secrets at runtime via Viper environment expansion from `config.yaml`.
+Pass the following variables when running the container:
+
+| Variable | Description |
+|---|---|
+| `GOOGLE_CLIENT_ID` | OAuth2 client ID from Google Cloud Console |
+| `GOOGLE_CLIENT_SECRET` | OAuth2 client secret from Google Cloud Console |
+| `GOOGLE_STATE` | Random string used as the OAuth2 state parameter (CSRF protection) |
+| `ALLOWED_EMAILS` | Comma-separated list of e-mail addresses permitted to log in |
+
+---
+
+## Example `docker run`
+
+```bash
+docker run --rm -p 8080:8080 \
+  -e GOOGLE_CLIENT_ID="your-google-client-id" \
+  -e GOOGLE_CLIENT_SECRET="your-google-client-secret" \
+  -e GOOGLE_STATE="random-state-string" \
+  -e ALLOWED_EMAILS="user@example.com,admin@example.com" \
+  ghcr.io/matiasmartin-labs/auth-provider-ms:latest
+```
+
+The service will be available at `http://localhost:8080`.
+
+> **Note**: For production deployments set `security.cookie.secure: true` and
+> `security.redirect.url` to your actual frontend origin either by mounting a
+> custom `config.yaml` or by adding Viper override env vars.


### PR DESCRIPTION
## Summary

Adds a production-ready multi-stage `Dockerfile` to containerize `auth-provider-ms`, along with build context optimization and GHCR publication guidance.

## Changes

- **`Dockerfile`** — Multi-stage build:
  - Builder: `golang:1.24-alpine` with `CGO_ENABLED=0 GOOS=linux -ldflags="-s -w"` for a minimal static binary
  - Runtime: `alpine:3.21` with `ca-certificates` installed for Google OAuth HTTPS calls
  - Non-root execution: dedicated `appuser` created via `adduser`
  - `config.yaml` baked in at `/app/config.yaml`
  - `EXPOSE 8080`, `ENTRYPOINT ["/app/provider-auth-ms"]`

- **`.dockerignore`** — Excludes `.git/`, docs, test artifacts, IDE files, and dev tooling to minimize build context

- **`docs/ghcr-publish.md`** — Step-by-step guide for `docker login`, `build`, `tag`, and `push` to `ghcr.io/matiasmartin-labs/auth-provider-ms`

## Notes

- `golang:1.24-alpine` is used as builder since `golang:1.25` is not yet published on Docker Hub.
- CI/GHA pipeline is out of scope for this change (deferred to a future issue).

Closes #10