### PR TITLE
feat(ci): implement unit-test-analysis workflow for Go with SonarCloud

### DIFF
--- a/.github/workflows/unit-test-analysis.yml
+++ b/.github/workflows/unit-test-analysis.yml
@@ -1,0 +1,54 @@
+name: unit-test-analysis
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**/*.go'
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    branches:
+      - main
+    paths:
+      - '**/*.go'
+
+jobs:
+  sonar-cloud:
+    name: Run SonarCloud Analysis
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Cache SonarQube packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Run tests with coverage
+        run: go test ./... -coverprofile=coverage.out
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args: >
+            -Dsonar.projectKey=com.mmartin:auth-provider-ms
+            -Dsonar.organization=matiasmartin-labs
+            -Dsonar.go.coverage.reportPaths=coverage.out


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/unit-test-analysis.yml` adapted from the Java/Maven reference workflow in `auth-ms`
- Triggers on `push` and `pull_request` to `main` for `**/*.go` paths
- Runs `go test ./... -coverprofile=coverage.out` and feeds the report to SonarCloud

## Changes

| Step | Detail |
|------|--------|
| Checkout | `actions/checkout@v4` with `fetch-depth: 0` (required by SonarCloud) |
| Go setup | `actions/setup-go@v5` with `go-version-file: go.mod` (Go 1.25.1) |
| Cache | Go modules cached by `setup-go`; SonarQube cache via `actions/cache@v4` |
| Tests | `go test ./... -coverprofile=coverage.out` |
| Analysis | `SonarSource/sonarcloud-github-action@master` with `SONAR_TOKEN` secret |

## Prerequisites

- Issue #17 (SONAR_TOKEN secret + SonarCloud project registration) must be completed for the workflow to succeed.

Closes #18