### PR TITLE
feat(ci): implement release-preview workflow

### DIFF
--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -1,0 +1,52 @@
+name: release-preview
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Bump type: major, minor or patch'
+        required: true
+        default: 'patch'
+  pull_request:
+    branches:
+      - main
+    types:
+      - synchronize
+      - labeled
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  generate-preview:
+    if: (
+      github.event.pull_request.base.ref == 'main') && (
+      contains(join(github.event.pull_request.labels.*.name, ','), 'release-type/patch') ||
+      contains(join(github.event.pull_request.labels.*.name, ','), 'release-type/minor') ||
+      contains(join(github.event.pull_request.labels.*.name, ','), 'release-type/major')
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Determine release type
+        uses: matiasmartin-labs/gha-deployments/determine-release-type@main
+        id: release_type
+
+      - name: Determine next version
+        id: calculate_version
+        uses: matiasmartin-labs/gha-deployments/determine-next-version@main
+        with:
+          release-type: ${{ steps.release_type.outputs.type }}
+
+      - name: Comment on PR
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            # 🎉 Release Preview
+
+            ## 🚀 Next Version
+            ![Version](https://img.shields.io/badge/version-${{ steps.calculate_version.outputs.new-version-tag }}-brightgreen)


### PR DESCRIPTION
Closes #19

## Type
- [x] New feature

## Summary
- Adds `.github/workflows/release-preview.yml` to post a release version preview comment on PRs targeting `main`
- Triggers on `pull_request` (synchronize/labeled) and `workflow_dispatch`
- Only runs when the PR has a `release-type/patch`, `release-type/minor`, or `release-type/major` label

## Changes

| File | Change |
|------|--------|
| `.github/workflows/release-preview.yml` | New workflow — release preview comment via custom GHA actions |

## Test Plan
- [ ] Add a `release-type/patch` label to a test PR targeting `main` and verify the workflow runs and posts a comment
- [ ] Trigger via `workflow_dispatch` with `bump: patch` and verify the version badge is correct

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers