### PR TITLE
feat(ci): implement generate-release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: release
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+permissions:
+  contents: write
+
+jobs:
+  create-release:
+    if: |
+      github.event.pull_request.merged == true && (
+        contains(join(github.event.pull_request.labels.*.name, ','), 'release-type/patch') ||
+        contains(join(github.event.pull_request.labels.*.name, ','), 'release-type/minor') ||
+        contains(join(github.event.pull_request.labels.*.name, ','), 'release-type/major')
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Determine release type
+        id: release_type
+        uses: matiasmartin-labs/gha-deployments/determine-release-type@main
+
+      - name: Determine next version
+        id: calculate_version
+        uses: matiasmartin-labs/gha-deployments/determine-next-version@main
+        with:
+          release-type: ${{ steps.release_type.outputs.type }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.calculate_version.outputs.new-version-tag }}
+          generate_release_notes: true
+          draft: false
+          prerelease: false
+          token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Closes #20

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only changes
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Summary

- Adds `.github/workflows/release.yml` that triggers on PR close to `main`
- Automatically creates a GitHub Release with semver tag when a `release-type/major|minor|patch` labeled PR is merged
- Uses `GH_TOKEN` (PAT) instead of `GITHUB_TOKEN` to allow triggering downstream workflows

## Changes

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | New workflow: creates GitHub Release on merged release-type PR |

## Test Plan

- [x] Workflow YAML is valid and follows the same pattern as `release-preview.yml`
- [x] Condition guards against non-merged PR closes and missing `release-type` labels
- [x] Uses `secrets.GH_TOKEN` as specified in the issue