### PR TITLE
feat(ci): implement build-and-promote workflow for Go with K8s manifest promotion

### DIFF
--- a/.github/workflows/build-and-promote.yml
+++ b/.github/workflows/build-and-promote.yml
@@ -1,0 +1,95 @@
+name: Build and Promote
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to build and promote (e.g. v1.2.3)'
+        required: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ghcr.io/matiasmartin-labs/auth-provider-ms
+
+jobs:
+  build:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "VERSION=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          else
+            echo "VERSION=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          fi
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.VERSION }}
+          platforms: linux/arm64
+
+  promote:
+    name: Promote K8s Manifests
+    runs-on: ubuntu-24.04-arm
+    needs: build
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "VERSION=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          else
+            echo "VERSION=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          fi
+      - name: Render K8s manifests
+        uses: matiasmartin-labs/gha-deployments/k8s-renderer@main
+        with:
+          input-dir: ./k8s
+          output-dir: ./k8s/manifests
+          version: ${{ steps.version.outputs.VERSION }}
+          docker-registry: ghcr.io/matiasmartin-labs
+          image-pull-secret: regcred
+          branch: ${{ github.ref }}
+      - name: Promote manifests to k8s-manifests branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          BRANCH="deploy-pr-${VERSION}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin k8s-manifests
+          git checkout -b "$BRANCH" origin/k8s-manifests
+          cp -r ./k8s/manifests/* .
+          git add .
+          git diff --cached --quiet || git commit -m "chore(k8s): promote manifests for ${VERSION}"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "chore(k8s): promote manifests for ${VERSION}" \
+            --body "Automated manifest promotion for release ${VERSION}" \
+            --base k8s-manifests \
+            --head "$BRANCH"

--- a/k8s/platform.yaml
+++ b/k8s/platform.yaml
@@ -1,10 +1,40 @@
-name: auth-provider-ms
-image: ghcr.io/matiasmartin-labs/auth-provider-ms
-port: 8080
-replicas: 2
-imagePullSecret: regcred
+app:
+  name: auth-provider-ms
+  port: 8080
+  part-of: auth-system
+  replicas: 2
+  metrics:
+    path: /metrics
+  health-check:
+    liveness:
+      path: /healthz
+      initial-delay-seconds: 5
+    readiness:
+      path: /readyz
+      initial-delay-seconds: 10
+  resources:
+    limits:
+      memory: 64Mi
+      cpu: 250m
+    requests:
+      memory: 32Mi
+      cpu: 50m
+
+namespace: matiasmartin-labs
+
+network:
+  host: auth-provider-ms.raspisrv.local
+
+mounts:
+  - name: jwt-keys-volume
+    mount-path: /etc/keys
+    read-only: true
+
+secret-volumes:
+  - name: jwt-keys-volume
+    default-mode: 420
+    secret-name: jwt-keys
+
 env:
-  - name: PORT
-    value: "8080"
-  - name: GIN_MODE
-    value: release
+  secrets:
+    - auth-provider-ms-credentials

--- a/k8s/platform.yaml
+++ b/k8s/platform.yaml
@@ -24,17 +24,3 @@ namespace: matiasmartin-labs
 
 network:
   host: auth-provider-ms.raspisrv.local
-
-mounts:
-  - name: jwt-keys-volume
-    mount-path: /etc/keys
-    read-only: true
-
-secret-volumes:
-  - name: jwt-keys-volume
-    default-mode: 420
-    secret-name: jwt-keys
-
-env:
-  secrets:
-    - auth-provider-ms-credentials

--- a/k8s/platform.yaml
+++ b/k8s/platform.yaml
@@ -1,0 +1,10 @@
+name: auth-provider-ms
+image: ghcr.io/matiasmartin-labs/auth-provider-ms
+port: 8080
+replicas: 2
+imagePullSecret: regcred
+env:
+  - name: PORT
+    value: "8080"
+  - name: GIN_MODE
+    value: release


### PR DESCRIPTION
Closes #21

## Type of change
- [x] New feature

## Summary
- Implements `.github/workflows/build-and-promote.yml` with two jobs: `build` (Docker image to GHCR) and `promote` (K8s manifest promotion to `k8s-manifests` branch)
- Creates `k8s/platform.yaml` application descriptor for `k8s-render` CLI

## Changes

| File | Change |
|------|--------|
| `.github/workflows/build-and-promote.yml` | New two-job CI/CD pipeline |
| `k8s/platform.yaml` | New k8s-render application descriptor |

## Test Plan
- [ ] Workflow syntax validated with actionlint
- [ ] Manual dry-run via `workflow_dispatch` with a test version
- [ ] Docker image pushed to GHCR with correct tag
- [ ] PR opened against `k8s-manifests` branch after promote job

## Contributor Checklist
- [x] Linked an approved issue
- [x] Conventional commit format
- [x] No secrets hardcoded