### PR TITLE
feat(ci): implement k8s-deploy workflow for Kubernetes deployment

### DIFF
--- a/.github/workflows/k8s-deploy.yml
+++ b/.github/workflows/k8s-deploy.yml
@@ -1,0 +1,30 @@
+name: K8s Deploy
+
+on:
+  pull_request:
+    branches:
+      - k8s-manifests
+    types:
+      - closed
+
+jobs:
+  deploy:
+    name: Deploy to Kubernetes
+    runs-on: self-hosted
+    if: github.event.pull_request.merged == true
+
+    steps:
+      - name: Checkout k8s-manifests
+        uses: actions/checkout@v4
+
+      - name: Install kubectl
+        run: |
+          curl -LO "https://dl.k8s.io/release/v1.28.1/bin/linux/arm64/kubectl"
+          chmod +x kubectl
+          sudo mv kubectl /usr/local/bin/kubectl
+
+      - name: Apply manifests
+        run: kubectl apply -f . -n matiasmartin-labs
+
+      - name: Check rollout status
+        run: kubectl rollout status deployment/auth-provider-ms -n matiasmartin-labs --timeout=30s

--- a/.github/workflows/k8s-deploy.yml
+++ b/.github/workflows/k8s-deploy.yml
@@ -24,7 +24,8 @@ jobs:
           sudo mv kubectl /usr/local/bin/kubectl
 
       - name: Apply manifests
-        run: kubectl apply -f . -n matiasmartin-labs
+        run: |
+          for f in *.yml; do kubectl apply -f "$f" -n matiasmartin-labs; done
 
       - name: Check rollout status
         run: kubectl rollout status deployment/auth-provider-ms -n matiasmartin-labs --timeout=30s


### PR DESCRIPTION
Closes #22

## Type
- [x] New feature

## Summary
- Adds `.github/workflows/k8s-deploy.yml` to deploy Kubernetes manifests when a PR to `k8s-manifests` is merged
- Applies all `*.yml` manifests in the branch root to namespace `matiasmartin-labs`
- Waits for rollout status of `deployment/auth-provider-ms`

## Changes

| File | Change |
|------|--------|
| `.github/workflows/k8s-deploy.yml` | New workflow file |

## Test Plan
- [ ] Workflow triggers only on merged PRs to `k8s-manifests`
- [ ] `kubectl apply` applies all manifests in branch root
- [ ] Rollout status is checked for `deployment/auth-provider-ms`

## Checklist
- [x] Linked an approved issue
- [x] Conventional commit format
- [x] No Go/Java changes needed (stack-agnostic)